### PR TITLE
exclude generate dir explicity

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,8 +31,9 @@ steps:
         key: "gosec"
         plugins:
           - docker#v5.11.0:
-              image: "securego/gosec:2.20.0"
-              command: ["-no-fail", "-exclude-generated", "-fmt sonarqube", "-out", "results.txt", "./..."]
+              image: "securego/gosec:latest"
+              always-pull: true
+              command: ["-no-fail", "-exclude-generated", "-exclude-dir=vanilla/_example/ent", "-fmt sonarqube", "-out", "results.txt", "./..."]
               environment:
                 - "GOTOOLCHAIN=auto"
         artifact_paths: ["results.txt"]

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/theopenlane/entx
 
 go 1.23.0
 
-godebug default=go1.22
-
 require (
 	entgo.io/contrib v0.6.0
 	entgo.io/ent v0.14.1

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/theopenlane/entx
 
 go 1.23.0
 
+godebug default=go1.22
+
 require (
 	entgo.io/contrib v0.6.0
 	entgo.io/ent v0.14.1


### PR DESCRIPTION
for some reason `exclude-generated` is not excluded the ent generated directory, so adding the directory explicity