### PR TITLE
fix admin search

### DIFF
--- a/genhooks/templates/search/graph.tpl
+++ b/genhooks/templates/search/graph.tpl
@@ -38,6 +38,15 @@ extend type Query{
         """
         query: String!
     ): SearchResultConnection
+    """
+    Admin search across all objects
+    """
+    adminSearch(
+        """
+        Search query
+        """
+        query: String!
+    ): SearchResultConnection
 }
 {{ range $object := $.Objects }}
 type  {{ $object.Name }}SearchResult {

--- a/genhooks/templates/search/query.tpl
+++ b/genhooks/templates/search/query.tpl
@@ -1,5 +1,9 @@
 query {{ $.Name }}Search($query: String!) {
+  {{- if eq $.Name "Admin" }}
+  adminSearch(query: $query) {
+  {{- else }}
   search(query: $query) {
+  {{- end }}
     nodes {
     {{- range $object := $.Objects }}
       ... on {{ $object.Name | toUpperCamel }}SearchResult {


### PR DESCRIPTION
`search` and `adminSearch` were returning the same thing so `admin` was getting overwritten. This adds the additional search type and corresponding resolver. 