### PR TITLE
feat: json searchability

### DIFF
--- a/annotation.go
+++ b/annotation.go
@@ -55,6 +55,10 @@ type SearchFieldAnnotation struct {
 	Searchable bool
 	// ExcludeAdmin indicates that the field will be excluded from the admin search which includes all fields by default
 	ExcludeAdmin bool
+	// JSONPath is the path to the field in the JSON object
+	JSONPath string
+	// JSONDotPath is the path to the field in the JSON object using dot notation
+	JSONDotPath string
 }
 
 // Name returns the name of the CascadeAnnotation
@@ -114,6 +118,22 @@ func SchemaSearchable(s bool) *SchemaGenAnnotation {
 func QueryGenSkip(skip bool) *QueryGenAnnotation {
 	return &QueryGenAnnotation{
 		Skip: skip,
+	}
+}
+
+// FieldJSONPathSearchable returns a new SearchFieldAnnotation with the searchable flag set and the JSONPath set
+func FieldJSONPathSearchable(path string) *SearchFieldAnnotation {
+	return &SearchFieldAnnotation{
+		JSONPath:   path,
+		Searchable: true,
+	}
+}
+
+// FieldJSONDotPathSearchable returns a new SearchFieldAnnotation with the searchable flag set and the JSONDotPath set
+func FieldJSONDotPathSearchable(path string) *SearchFieldAnnotation {
+	return &SearchFieldAnnotation{
+		JSONDotPath: path,
+		Searchable:  true,
 	}
 }
 

--- a/genhooks/gensearch.go
+++ b/genhooks/gensearch.go
@@ -345,7 +345,6 @@ func entSkip(field *load.Field) bool {
 				return true
 			case entAnt.Skip.Is(entgql.SkipWhereInput):
 				return true
-
 			}
 		}
 	}

--- a/genhooks/gensearch_test.go
+++ b/genhooks/gensearch_test.go
@@ -8,6 +8,7 @@ import (
 	"entgo.io/ent/entc/load"
 	"entgo.io/ent/schema/field"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/theopenlane/entx"
 )
 

--- a/genhooks/gensearch_test.go
+++ b/genhooks/gensearch_test.go
@@ -130,6 +130,20 @@ func TestEntSkip(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "sensitive skipped",
+			input: &load.Field{
+				Sensitive: true,
+			},
+			expected: true,
+		},
+		{
+			name: "not sensitive, not skipped",
+			input: &load.Field{
+				Sensitive: false,
+			},
+			expected: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -333,6 +347,98 @@ func TestIsAdminFieldSearchable(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := isAdminFieldSearchable(tc.input)
+
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestGetPathAnnotation(t *testing.T) {
+	searchAnt := &entx.SearchFieldAnnotation{}
+
+	testCases := []struct {
+		name     string
+		input    *load.Field
+		expected string
+	}{
+		{
+			name: "has path",
+			input: &load.Field{
+				Annotations: map[string]interface{}{
+					searchAnt.Name(): &entx.SearchFieldAnnotation{
+						JSONPath: "path",
+					},
+				},
+			},
+			expected: "path",
+		},
+		{
+			name: "no path",
+			input: &load.Field{
+				Annotations: map[string]interface{}{
+					searchAnt.Name(): &entx.SearchFieldAnnotation{},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "no annotation",
+			input: &load.Field{
+				Annotations: map[string]interface{}{},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getPathAnnotation(tc.input)
+
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestGetDotPathAnnotation(t *testing.T) {
+	searchAnt := &entx.SearchFieldAnnotation{}
+
+	testCases := []struct {
+		name     string
+		input    *load.Field
+		expected string
+	}{
+		{
+			name: "has path",
+			input: &load.Field{
+				Annotations: map[string]interface{}{
+					searchAnt.Name(): &entx.SearchFieldAnnotation{
+						JSONDotPath: "path",
+					},
+				},
+			},
+			expected: "path",
+		},
+		{
+			name: "no path",
+			input: &load.Field{
+				Annotations: map[string]interface{}{
+					searchAnt.Name(): &entx.SearchFieldAnnotation{},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "no annotation",
+			input: &load.Field{
+				Annotations: map[string]interface{}{},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getDotPathAnnotation(tc.input)
 
 			assert.Equal(t, tc.expected, result)
 		})

--- a/mixin/tagmixin.go
+++ b/mixin/tagmixin.go
@@ -4,6 +4,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/mixin"
+
 	"github.com/theopenlane/entx"
 )
 

--- a/mixin/tagmixin.go
+++ b/mixin/tagmixin.go
@@ -4,6 +4,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/mixin"
+	"github.com/theopenlane/entx"
 )
 
 // TagMixin holds the schema definition for the tags
@@ -17,6 +18,9 @@ func (t TagMixin) Fields() []ent.Field {
 		field.Strings("tags").
 			Comment("tags associated with the object").
 			Default([]string{}).
+			Annotations(
+				entx.FieldSearchable(),
+			).
 			Optional(),
 	}
 }


### PR DESCRIPTION
- Adds path based searching options for `JSONB` fields; these are all `like` based searches. When we get to more specific object searches we should look at the `ValueEq`/`StringEq` vs `StringContains` 
- Defaults to adding tags as searchable in the `TagMixin`
- Fixes bad uppercase by using the `templates.ToGo` functions from `gqlgen` library
- Changes `isFieldTypeExcluded` from a exlcude list to an include list (we can only (want to) really search on text or json fields, and not on int, bools, etc). 


Tested against our `core` repo:

Able to search on `tags`, e.g 

```
go run cmd/cli/main.go search -q "test" 
...
Templates
  ID                          JSONCONFIG                                                              NAME     TAGS    
  01J773T3BCNS05QMH0PFJEC0FN  map[$defs:map[BusinessPartner:map[additionalProperties:false            invoice  [test]  
                              description:BusinessPartner is the business partner (customer)                           
...
```

As well as a path in a json field:

```
(⎈ |default:default)➜  core git:(search-greatness) ✗ go run cmd/cli/main.go search -q "/invoice/config" -z json
{
  "data": {
    "search": {
      "nodes": [
        {
          "Templates": [
            {
              "id": "01J773T3BCNS05QMH0PFJEC0FN",
              "jsonconfig": {
                "$defs": {
     ...
                "$id": "https://github.com/theopenlane/jsonschema-templates/invoice/config",
 ...
```