### PR TITLE
feat: add prefixed human readable id option, change mapping id default

### DIFF
--- a/customtypes/prefixedIdentifier.go
+++ b/customtypes/prefixedIdentifier.go
@@ -1,0 +1,44 @@
+package customtypes
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"strings"
+
+	"entgo.io/ent/schema/field"
+)
+
+// PrefixedIdentifier is a custom type that implements the TypeValueScanner interface
+type PrefixedIdentifier struct {
+	prefix string
+}
+
+// NewPrefixedIdentifier returns a new PrefixedIdentifier with the given prefix
+func NewPrefixedIdentifier(prefix string) PrefixedIdentifier {
+	return PrefixedIdentifier{prefix: prefix}
+}
+
+// Value implements the TypeValueScanner.Value method.
+func (p PrefixedIdentifier) Value(s string) (driver.Value, error) {
+	return strings.TrimPrefix(s, p.prefix+"-"), nil
+}
+
+// ScanValue implements the TypeValueScanner.ScanValue method.
+func (PrefixedIdentifier) ScanValue() field.ValueScanner {
+	return &sql.NullString{}
+}
+
+// FromValue implements the TypeValueScanner.FromValue method.
+func (p PrefixedIdentifier) FromValue(v driver.Value) (string, error) {
+	s, ok := v.(*sql.NullString)
+	if !ok {
+		return "", fmt.Errorf("unexpected input for FromValue: %T", v) // nolint:err113
+	}
+
+	if !s.Valid {
+		return "", nil
+	}
+
+	return fmt.Sprintf("%s-%06s", p.prefix, s.String), nil
+}

--- a/customtypes/prefixedIdentifier.go
+++ b/customtypes/prefixedIdentifier.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"entgo.io/ent/schema/field"
@@ -21,7 +22,17 @@ func NewPrefixedIdentifier(prefix string) PrefixedIdentifier {
 
 // Value implements the TypeValueScanner.Value method.
 func (p PrefixedIdentifier) Value(s string) (driver.Value, error) {
-	return strings.TrimPrefix(s, p.prefix+"-"), nil
+	value := strings.TrimPrefix(s, p.prefix+"-")
+	if value == "" {
+		return "", nil
+	}
+
+	trimValue, err := strconv.Atoi(value)
+	if err != nil {
+		return nil, err
+	}
+
+	return fmt.Sprintf("%d", trimValue), nil
 }
 
 // ScanValue implements the TypeValueScanner.ScanValue method.

--- a/customtypes/prefixedIdentifier_test.go
+++ b/customtypes/prefixedIdentifier_test.go
@@ -1,0 +1,96 @@
+package customtypes
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixedIdentifierValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		input  string
+		want   driver.Value
+	}{
+		{
+			name:   "with prefix",
+			prefix: "test",
+			input:  "test-000001",
+			want:   "1",
+		},
+		{
+			name:   "without prefix",
+			prefix: "test",
+			input:  "123",
+			want:   "123",
+		},
+		{
+			name:   "empty input",
+			prefix: "test",
+			input:  "",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := PrefixedIdentifier{prefix: tt.prefix}
+			got, err := p.Value(tt.input)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+func TestPrefixedIdentifierFromValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefix  string
+		input   driver.Value
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "valid input",
+			prefix: "test",
+			input:  &sql.NullString{String: "1", Valid: true},
+			want:   "test-000001",
+		},
+		{
+			name:   "valid input",
+			prefix: "test",
+			input:  &sql.NullString{String: "999999", Valid: true},
+			want:   "test-999999",
+		},
+		{
+			name:    "invalid input type",
+			prefix:  "test",
+			input:   "invalid",
+			wantErr: true,
+		},
+		{
+			name:   "null string input",
+			prefix: "test",
+			input:  &sql.NullString{String: "", Valid: false},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := PrefixedIdentifier{prefix: tt.prefix}
+
+			got, err := p.FromValue(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Breaking**: Changes the `mapping_id` to not be included by default, this was an idea we had but never really worked so want to switch this to not be included by default

Adds an optional `identifier` field that is a prefixed string ID. This will allow us to show the ID that a human can actually read but not used as the PK. 

```
          "identifier": "TSK-000001",
```

