### PR TITLE
bug: fix issue with atlas migrations + search field

### DIFF
--- a/customtypes/prefixedIdentifier.go
+++ b/customtypes/prefixedIdentifier.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"entgo.io/ent/schema/field"
+	"github.com/rs/zerolog/log"
 )
 
 // PrefixedIdentifier is a custom type that implements the TypeValueScanner interface
@@ -24,15 +25,17 @@ func NewPrefixedIdentifier(prefix string) PrefixedIdentifier {
 func (p PrefixedIdentifier) Value(s string) (driver.Value, error) {
 	value := strings.TrimPrefix(s, p.prefix+"-")
 	if value == "" {
-		return "", nil
+		return 0, nil
 	}
 
 	trimValue, err := strconv.Atoi(value)
 	if err != nil {
-		return nil, err
+		log.Debug().Err(err).Msg("failed to convert string to int, skipping")
+
+		return 0, nil
 	}
 
-	return fmt.Sprintf("%d", trimValue), nil
+	return trimValue, nil
 }
 
 // ScanValue implements the TypeValueScanner.ScanValue method.

--- a/customtypes/prefixedIdentifier_test.go
+++ b/customtypes/prefixedIdentifier_test.go
@@ -18,21 +18,27 @@ func TestPrefixedIdentifierValue(t *testing.T) {
 	}{
 		{
 			name:   "with prefix",
-			prefix: "test",
-			input:  "test-000001",
-			want:   "1",
+			prefix: "TSK",
+			input:  "TSK-000006",
+			want:   6,
+		},
+		{
+			name:   "with wrong prefix",
+			prefix: "TEST",
+			input:  "TSK-000006",
+			want:   0,
 		},
 		{
 			name:   "without prefix",
 			prefix: "test",
 			input:  "123",
-			want:   "123",
+			want:   123,
 		},
 		{
 			name:   "empty input",
 			prefix: "test",
 			input:  "",
-			want:   "",
+			want:   0,
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/theopenlane/entx
 go 1.23.3
 
 require (
+	ariga.io/atlas v0.26.1
 	entgo.io/contrib v0.6.0
 	entgo.io/ent v0.14.1
 	github.com/99designs/gqlgen v0.17.63
@@ -20,7 +21,6 @@ require (
 )
 
 require (
-	ariga.io/atlas v0.26.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/agnivade/levenshtein v1.2.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect

--- a/mixin/idmixin.go
+++ b/mixin/idmixin.go
@@ -1,10 +1,10 @@
 package mixin
 
 import (
+	"ariga.io/atlas/sql/postgres"
 	"entgo.io/contrib/entgql"
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
-	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/mixin"
 
@@ -64,14 +64,13 @@ func (i IDMixin) Fields() []ent.Field {
 			field.String("identifier").
 				Comment("a prefixed incremental field to use as a human readable identifier").
 				SchemaType(map[string]string{
-					dialect.Postgres: "SERIAL",
+					dialect.Postgres: postgres.TypeBigSerial,
 				}).
 				ValueScanner(customtypes.NewPrefixedIdentifier(i.HumanIdentifierPrefix)).
 				Immutable().
 				Annotations(
 					entx.FieldSearchable(),
 					entgql.Skip(entgql.SkipMutationCreateInput|entgql.SkipMutationUpdateInput),
-					entsql.DefaultExpr("nextval('identifier_id_seq')"),
 				).
 				Unique(),
 		)


### PR DESCRIPTION
When using atlas auto migrations (which we use in our tests) I was getting this error:

```
Received unexpected error:
        	            	sql/schema: modify "procedure_history" table: pq: syntax error at end of input
```

Using the `postgres.TypeBigSerial` and not the default expr seems to fix this; the default expression was used because with with just `SERIAL` we would get an error for a required field not being set. 

Fixes the return of `Value` to be an `int` instead of a string, when querying the database we need an int, the return to the user is a string. Tests updated to reflect the correct values. 