### PR TITLE
golangci-lint upgrade v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,44 +1,54 @@
+version: "2"
 run:
-  timeout: 10m
   allow-serial-runners: true
-  concurrency: 0
-linters-settings:
-  goimports:
-    local-prefixes: github.com/theopenlane/entx
-  gofumpt:
-    extra-rules: true
-  gosec:
-    exclude-generated: true
-  revive:
-    ignore-generated-header: true
 linters:
   enable:
     - bodyclose
-    - errcheck
+    - err113
     - gocritic
     - gocyclo
-    - err113
-    - gofmt
-    - goimports
-    - mnd
-    - gosimple
-    - govet
     - gosec
-    - ineffassign
     - misspell
+    - mnd
     - noctx
     - revive
     - staticcheck
-    - stylecheck
-    - typecheck
-    - unused
     - whitespace
     - wsl
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - vanilla/*
+      - .buildkite/*
+      - .github/*
+      - templates/*
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   fix: true
-  exclude-use-default: true
-  exclude-dirs:
-    - vanilla/*
-    - .buildkite/*
-    - .github/*
-    - templates/*
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/theopenlane/entx
+  exclusions:
+    generated: lax
+    paths:
+      - vanilla/*
+      - .buildkite/*
+      - .github/*
+      - templates/*
+      - third_party$
+      - builtin$
+      - examples$

--- a/client.go
+++ b/client.go
@@ -1,7 +1,6 @@
 package entx
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -140,8 +139,8 @@ func (c *EntClientConfig) NewEntDB(dataSource string) (*entsql.Driver, error) {
 }
 
 // Healthcheck pings the DB to check if the connection is working
-func Healthcheck(client *entsql.Driver) func(ctx context.Context) error {
-	return func(ctx context.Context) error {
+func Healthcheck(client *entsql.Driver) func() error {
+	return func() error {
 		if err := client.DB().Ping(); err != nil {
 			return fmt.Errorf("db connection failed: %w", err)
 		}

--- a/gqlhooks.go
+++ b/gqlhooks.go
@@ -6,7 +6,7 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
-//nolint:err113
+//nolint:err113,revive
 var (
 	addJSONScalar = func(g *gen.Graph, s *ast.Schema) error {
 		s.Types["JSON"] = &ast.Definition{

--- a/history/enthistory.go
+++ b/history/enthistory.go
@@ -5,7 +5,7 @@ import (
 	"entgo.io/ent/entc/gen"
 )
 
-type ExtensionOption = func(*HistoryExtension)
+type ExtensionOption = func(*Extension)
 
 // UpdatedBy is a struct that holds the key and type for the updated_by field
 type UpdatedBy struct {
@@ -49,15 +49,15 @@ func (c Config) Name() string {
 	return "HistoryConfig"
 }
 
-// HistoryExtension implements entc.Extension.
-type HistoryExtension struct {
+// Extension implements entc.Extension
+type Extension struct {
 	entc.DefaultExtension
 	config *Config
 }
 
 // New creates a new history extension
-func New(opts ...ExtensionOption) *HistoryExtension {
-	extension := &HistoryExtension{
+func New(opts ...ExtensionOption) *Extension {
+	extension := &Extension{
 		// Set configuration defaults that can get overridden with ExtensionOption
 		config: &Config{
 			SchemaPath:      "./schema",
@@ -75,7 +75,7 @@ func New(opts ...ExtensionOption) *HistoryExtension {
 
 // Templates returns the generated templates which include the client, history query, history from mutation
 // and an optional auditing template
-func (h *HistoryExtension) Templates() []*gen.Template {
+func (h *Extension) Templates() []*gen.Template {
 	templates := []*gen.Template{
 		parseTemplate("historyFromMutation", "templates/historyFromMutation.tmpl"),
 		parseTemplate("historyQuery", "templates/historyQuery.tmpl"),
@@ -90,47 +90,47 @@ func (h *HistoryExtension) Templates() []*gen.Template {
 }
 
 // Annotations of the HistoryExtension
-func (h *HistoryExtension) Annotations() []entc.Annotation {
+func (h *Extension) Annotations() []entc.Annotation {
 	return []entc.Annotation{
 		h.config,
 	}
 }
 
 // SetFirstRun sets the first run value for the history extension outside of the options
-func (h *HistoryExtension) SetFirstRun(firstRun bool) {
+func (h *Extension) SetFirstRun(firstRun bool) {
 	h.config.Auth.FirstRun = firstRun
 }
 
 // WithAuditing allows you to turn on the code generation for the `.Audit()` method
 func WithAuditing() ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.Auditing = true
 	}
 }
 
 func WithAuthzPolicy() ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.Auth.Enabled = true
 	}
 }
 
 // WithGQLQuery adds the entgql Query annotation to the history schema in order to allow for querying
 func WithGQLQuery() ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.Query = true
 	}
 }
 
 // WithHistoryTimeIndex allows you to add an index to the "history_time" fields
 func WithHistoryTimeIndex() ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.HistoryTimeIndex = true
 	}
 }
 
 // WithImmutableFields allows you to set all tracked fields in history to Immutable
 func WithImmutableFields() ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.FieldProperties.Immutable = true
 	}
 }
@@ -138,7 +138,7 @@ func WithImmutableFields() ExtensionOption {
 // WithNillableFields allows you to set all tracked fields in history to Nillable
 // except enthistory managed fields (history_time, ref, operation, updated_by, & deleted_by)
 func WithNillableFields() ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.FieldProperties.Nillable = true
 	}
 }
@@ -147,7 +147,7 @@ func WithNillableFields() ExtensionOption {
 // This can be used to set a schema name for multi-schema migrations and SchemaConfig feature
 // https://entgo.io/docs/multischema-migrations/
 func WithSchemaName(schemaName string) ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.SchemaName = schemaName
 	}
 }
@@ -155,7 +155,7 @@ func WithSchemaName(schemaName string) ExtensionOption {
 // WithSchemaPath allows you to set an alternative schemaPath
 // Defaults to "./schema"
 func WithSchemaPath(schemaPath string) ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.SchemaPath = schemaPath
 	}
 }
@@ -163,21 +163,21 @@ func WithSchemaPath(schemaPath string) ExtensionOption {
 // WithFirstRun tells the extension to generate the history schema on the first run
 // which leaves out the entfga policy
 func WithFirstRun(firstRun bool) ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.Auth.FirstRun = firstRun
 	}
 }
 
 // WithAllowedRelation sets the relation that should be used to restrict all audit log queries to users with that role
 func WithAllowedRelation(relation string) ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.Auth.AllowedRelation = relation
 	}
 }
 
 // WithSkipper allows you to set a skipper function to skip history tracking
 func WithSkipper(skipper string) ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.Skipper = skipper
 	}
 }
@@ -185,7 +185,7 @@ func WithSkipper(skipper string) ExtensionOption {
 // WithUpdatedBy sets the key and type for pulling updated_by from the context,
 // usually done via a middleware to track which users are making which changes
 func WithUpdatedBy(key string, valueType ValueType) ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.IncludeUpdatedBy = true
 		h.config.UpdatedBy = &UpdatedBy{
 			key:       key,
@@ -197,7 +197,7 @@ func WithUpdatedBy(key string, valueType ValueType) ExtensionOption {
 
 // WithUpdatedByFromSchema uses the original update_by value in the schema and includes in the audit results
 func WithUpdatedByFromSchema(valueType ValueType, nillable bool) ExtensionOption {
-	return func(h *HistoryExtension) {
+	return func(h *Extension) {
 		h.config.IncludeUpdatedBy = true
 		h.config.UpdatedBy = &UpdatedBy{
 			valueType: ValueTypeString,

--- a/history/generateschemas.go
+++ b/history/generateschemas.go
@@ -77,7 +77,7 @@ var (
 // GenerateSchemas generates the history schema for all schemas in the schema path
 // this should be called before the entc.Generate call
 // so the schemas exist at the time of code generation
-func (h *HistoryExtension) GenerateSchemas() error {
+func (h *Extension) GenerateSchemas() error {
 	graph, err := entc.LoadGraph(h.config.SchemaPath, &gen.Config{})
 	if err != nil {
 		return fmt.Errorf("%w: failed loading ent graph: %v", ErrFailedToGenerateTemplate, err)

--- a/history/hook.go
+++ b/history/hook.go
@@ -33,8 +33,8 @@ func On(hk ent.Hook, op ent.Op) ent.Hook {
 	}
 }
 
-// HistoryHooks returns a list of hooks that can be used to create history entries
-func HistoryHooks[T Mutation]() []ent.Hook {
+// Hooks returns a list of hooks that can be used to create history entries
+func Hooks[T Mutation]() []ent.Hook {
 	return []ent.Hook{
 		On(historyHookCreate[T](), ent.OpCreate),
 		On(historyHookUpdate[T](), ent.OpUpdate|ent.OpUpdateOne),


### PR DESCRIPTION
- ran `golangci-lint migrate`
- updated failures due to `revive` linter
 
renamed exported functions means this includes _breaking changes_