### PR TITLE
feat: add pagination to search

### DIFF
--- a/genhooks/gensearch.go
+++ b/genhooks/gensearch.go
@@ -91,21 +91,13 @@ func getInputData(g *gen.Graph) search {
 		// skipSearch must be false
 		// there must be at least one searchable field other than the ID field
 		if checkSchemaGenSkip(f) || !includeSchemaForSearch(f) {
-			log.Warn().Msgf("Skipping search schema generation for %s", f.Name)
 			continue
 		}
 
 		fields, adminFields := GetSearchableFields(f.Name, g)
 
-		log.Debug().Interface("fields", fields).Msgf("Searchable fields for %s", f.Name)
-
-		if len(fields) <= 1 {
-			log.Warn().Msgf("No searchable fields for %s", f.Name)
-			continue
-		}
-
 		// only add object if there are searchable fields other than the ID field (ID is always searchable)
-		if len(fields) > 0 {
+		if len(fields) > 1 {
 			inputData.Objects = append(inputData.Objects, Object{
 				Name:        f.Name,
 				Fields:      fields,

--- a/genhooks/templates/search/graph.tpl
+++ b/genhooks/templates/search/graph.tpl
@@ -9,20 +9,31 @@ extend type Query{
     {{ $.Name | toLower }}{{ $object.Name | toUpperCamel }}Search(
     {{- end }}
         """
-        Search query
+        Query string to search across objects
         """
         query: String!
-    ): {{ $object.Name }}SearchResult
+        """
+        Returns the elements in the list that come after the specified cursor.
+        """
+        after: Cursor
+        """
+        Returns the first _n_ elements from the list.
+        """
+        first: Int
+        """
+        Returns the elements in the list that come before the specified cursor.
+        """
+        before: Cursor
+        """
+        Returns the last _n_ elements from the list.
+        """
+        last: Int
+    ): {{ $object.Name | toUpperCamel }}Connection
     {{- end }}
 }
 
 {{- if eq $.Name "Global" }}
-union SearchResult =
-  {{- range $object := $.Objects }}
-  | {{ $object.Name | toUpperCamel }}SearchResult
-  {{- end }}
-
-type SearchResultConnection {
+type SearchResults{
   """
   Information to aid in pagination.
   """
@@ -31,10 +42,9 @@ type SearchResultConnection {
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
-  """
-  A list of nodes with results.
-  """
-  nodes: [SearchResult!]!
+  {{- range $object := $.Objects }}
+  {{ $object.Name | toLower |toPlural }}: {{ $object.Name | toUpperCamel }}Connection
+  {{- end }}
 }
 
 extend type Query{
@@ -43,23 +53,50 @@ extend type Query{
     """
     search(
         """
-        Search query
+        Query string to search across objects
         """
         query: String!
-    ): SearchResultConnection
+        """
+        Returns the elements in the list that come after the specified cursor.
+        """
+        after: Cursor
+        """
+        Returns the first _n_ elements from the list.
+        """
+        first: Int
+        """
+        Returns the elements in the list that come before the specified cursor.
+        """
+        before: Cursor
+        """
+        Returns the last _n_ elements from the list.
+        """
+        last: Int
+    ): SearchResults
     """
     Admin search across all objects
     """
     adminSearch(
         """
-        Search query
+        Query string to search across objects
         """
         query: String!
-    ): SearchResultConnection
+        """
+        Returns the elements in the list that come after the specified cursor.
+        """
+        after: Cursor
+        """
+        Returns the first _n_ elements from the list.
+        """
+        first: Int
+        """
+        Returns the elements in the list that come before the specified cursor.
+        """
+        before: Cursor
+        """
+        Returns the last _n_ elements from the list.
+        """
+        last: Int
+    ): SearchResults
 }
-{{ range $object := $.Objects }}
-type  {{ $object.Name }}SearchResult {
-   {{ $object.Name | toLower | toPlural }}: [ {{ $object.Name | toUpperCamel}}!]
-}
-{{ end }}
 {{- end }}

--- a/genhooks/templates/search/query.tpl
+++ b/genhooks/templates/search/query.tpl
@@ -4,22 +4,23 @@ query {{ $.Name }}Search($query: String!) {
   {{- else }}
   search(query: $query) {
   {{- end }}
-    nodes {
     {{- range $object := $.Objects }}
-      ... on {{ $object.Name | toUpperCamel }}SearchResult {
         {{ $object.Name| toLower | toPlural }} {
-          {{- if eq $.Name "Admin" }}
-          {{- range $field := $object.AdminFields }}
-          {{ $field.Name | toLower }}
-          {{- end }}
-          {{- else }}
-          {{- range $field := $object.Fields }}
-          {{ $field.Name  | toLower }}
-          {{- end }}
-          {{- end }}
+          edges {
+            node {
+              {{- if eq $.Name "Admin" }}
+              {{- range $field := $object.AdminFields }}
+              {{ $field.Name | toLower }}
+              {{- end }}
+              {{- else }}
+              {{- range $field := $object.Fields }}
+              {{ $field.Name  | toLower }}
+              {{- end }}
+              {{- end }}
+            }
+          }
         }
-      }
     {{- end }}
-    }
+
   }
 }

--- a/genhooks/templates/search/query.tpl
+++ b/genhooks/templates/search/query.tpl
@@ -4,8 +4,16 @@ query {{ $.Name }}Search($query: String!) {
   {{- else }}
   search(query: $query) {
   {{- end }}
+        totalCount
     {{- range $object := $.Objects }}
         {{ $object.Name| toLower | toPlural }} {
+          totalCount
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
           edges {
             node {
               {{- if eq $.Name "Admin" }}


### PR DESCRIPTION
breaking changes here will also require gqlgen-plugin changes

results are now formatting as the `Connection` type, not their own special type:

```
{
  "data": {
    "search": {
      "groups": {
        "totalCount": 1,
        "pageInfo": {
          "hasNextPage": false,
          "hasPreviousPage": false,
          "startCursor": "gaFpujAxSlJHU0dRSldUTVNEQjVOWEExUUVLM1Iz",
          "endCursor": "gaFpujAxSlJHU0dRSldUTVNEQjVOWEExUUVLM1Iz"
        },
        "edges": [
          {
            "node": {
              "id": "01JRGSGQJWTMSDB5NXA1QEK3R3",
              "name": "Admins"
            }
          }
        ]
      }
    }
  },
  "extensions": {
    "auth": {
      "authentication_type": "api_token",
      "authorized_organization": [
        "01JRGSGQF42QVDP6619NMMAN4Z"
      ]
    },
    "server_latency": "7.108667ms",
    "trace_id": "TokiIYONaFTWUxqdsYYmThofdIMIlFpo"
  }
}
```