### PR TITLE
bug: fix identation for format doesn't argue

### DIFF
--- a/genhooks/templates/search/query.tpl
+++ b/genhooks/templates/search/query.tpl
@@ -4,31 +4,30 @@ query {{ $.Name }}Search($query: String!) {
   {{- else }}
   search(query: $query) {
   {{- end }}
-        totalCount
+    totalCount
     {{- range $object := $.Objects }}
-        {{ $object.Name| toLower | toPlural }} {
-          totalCount
-          pageInfo {
-            hasNextPage
-            hasPreviousPage
-            startCursor
-            endCursor
-          }
-          edges {
-            node {
-              {{- if eq $.Name "Admin" }}
-              {{- range $field := $object.AdminFields }}
-              {{ $field.Name | toLower }}
-              {{- end }}
-              {{- else }}
-              {{- range $field := $object.Fields }}
-              {{ $field.Name  | toLower }}
-              {{- end }}
-              {{- end }}
-            }
-          }
+    {{ $object.Name| toLower | toPlural }} {
+      totalCount
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      edges {
+        node {
+          {{- if eq $.Name "Admin" }}
+          {{- range $field := $object.AdminFields }}
+          {{ $field.Name | toLower }}
+          {{- end }}
+          {{- else }}
+          {{- range $field := $object.Fields }}
+          {{ $field.Name  | toLower }}
+          {{- end }}
+          {{- end }}
         }
+      }
+    }
     {{- end }}
-
   }
 }


### PR DESCRIPTION
bad indentation meant graphql formatter would fix it, and then go generate would put it back 