### PR TITLE
remove duplicate id index

### DIFF
--- a/mixin/idmixin.go
+++ b/mixin/idmixin.go
@@ -95,10 +95,7 @@ func (i IDMixin) Fields() []ent.Field {
 
 // Indexes of the IDMixin
 func (i IDMixin) Indexes() []ent.Index {
-	idx := []ent.Index{
-		index.Fields("id").
-			Unique(), // enforce globally unique ids
-	}
+	idx := []ent.Index{}
 
 	if i.HumanIdentifierPrefix != "" && !i.SingleFieldIndex {
 		idxField := "owner_id"


### PR DESCRIPTION
ent automatically adds the pkey:

```
subcontrols_pkey | CREATE UNIQUE INDEX subcontrols_pkey ON public.subcontrols USING btree (id)
```

so these are duplicates:

```
subcontrol_id | CREATE UNIQUE INDEX subcontrol_id ON public.subcontrols USING btree (id)
```

Tested locally, duplicate is removed:

```
core=# SELECT indexname, indexdef
core-# FROM pg_indexes
core-# WHERE tablename = 'subcontrols';
                indexname                |                                                                      indexdef                                                                      
-----------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------
 subcontrols_pkey                        | CREATE UNIQUE INDEX subcontrols_pkey ON public.subcontrols USING btree (id)
 subcontrol_control_id_ref_code          | CREATE UNIQUE INDEX subcontrol_control_id_ref_code ON public.subcontrols USING btree (control_id, ref_code) WHERE (deleted_at IS NULL)
 subcontrol_display_id_owner_id          | CREATE UNIQUE INDEX subcontrol_display_id_owner_id ON public.subcontrols USING btree (display_id, owner_id)
 subcontrol_id                           | CREATE UNIQUE INDEX subcontrol_id ON public.subcontrols USING btree (id)
 subcontrol_owner_id                     | CREATE INDEX subcontrol_owner_id ON public.subcontrols USING btree (owner_id) WHERE (deleted_at IS NULL)
 subcontrol_control_id_ref_code_owner_id | CREATE INDEX subcontrol_control_id_ref_code_owner_id ON public.subcontrols USING btree (control_id, ref_code, owner_id) WHERE (deleted_at IS NULL)
(6 rows)

core=# SELECT indexname, indexdef                                                                                                                                                                                                                    FROM pg_indexes                                                                                                                                                                                                                                      WHERE tablename = 'subcontrols';
                indexname                |                                                                      indexdef                                                                      
-----------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------
 subcontrols_pkey                        | CREATE UNIQUE INDEX subcontrols_pkey ON public.subcontrols USING btree (id)
 subcontrol_control_id_ref_code          | CREATE UNIQUE INDEX subcontrol_control_id_ref_code ON public.subcontrols USING btree (control_id, ref_code) WHERE (deleted_at IS NULL)
 subcontrol_display_id_owner_id          | CREATE UNIQUE INDEX subcontrol_display_id_owner_id ON public.subcontrols USING btree (display_id, owner_id)
 subcontrol_owner_id                     | CREATE INDEX subcontrol_owner_id ON public.subcontrols USING btree (owner_id) WHERE (deleted_at IS NULL)
 subcontrol_control_id_ref_code_owner_id | CREATE INDEX subcontrol_control_id_ref_code_owner_id ON public.subcontrols USING btree (control_id, ref_code, owner_id) WHERE (deleted_at IS NULL)
 ```
