### PR TITLE
bug: lowercase breaks mutli-word schemas

### DIFF
--- a/exportable_gen.go
+++ b/exportable_gen.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"text/template"
 
 	"entgo.io/ent/entc"
 	"entgo.io/ent/entc/gen"
+	"github.com/stoewer/go-strcase"
 	"golang.org/x/tools/imports"
 )
 
@@ -93,7 +93,7 @@ var ExportableSchemas = map[string]bool{
 
 // IsSchemaExportable checks if a schema name is exportable
 func IsSchemaExportable(schemaName string) bool {
-	return ExportableSchemas[strings.ToLower(schemaName)]
+	return ExportableSchemas[schemaName]
 }
 
 // ValidateExportType validates that an export type corresponds to an exportable schema
@@ -131,7 +131,7 @@ func (e *ExportableGenerator) findExportableSchemas(graph *gen.Graph) []string {
 	for _, schema := range graph.Schemas {
 		if raw, ok := schema.Annotations[ant.Name()]; ok {
 			if err := ant.Decode(raw); err == nil {
-				exportableSchemas = append(exportableSchemas, strings.ToLower(schema.Name))
+				exportableSchemas = append(exportableSchemas, strcase.UpperSnakeCase(schema.Name))
 			}
 		}
 	}

--- a/vanilla/_example/ent/client.go
+++ b/vanilla/_example/ent/client.go
@@ -262,8 +262,8 @@ func (c *OrgMembershipClient) Update() *OrgMembershipUpdate {
 }
 
 // UpdateOne returns an update builder for the given entity.
-func (c *OrgMembershipClient) UpdateOne(om *OrgMembership) *OrgMembershipUpdateOne {
-	mutation := newOrgMembershipMutation(c.config, OpUpdateOne, withOrgMembership(om))
+func (c *OrgMembershipClient) UpdateOne(_m *OrgMembership) *OrgMembershipUpdateOne {
+	mutation := newOrgMembershipMutation(c.config, OpUpdateOne, withOrgMembership(_m))
 	return &OrgMembershipUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
 }
 
@@ -280,8 +280,8 @@ func (c *OrgMembershipClient) Delete() *OrgMembershipDelete {
 }
 
 // DeleteOne returns a builder for deleting the given entity.
-func (c *OrgMembershipClient) DeleteOne(om *OrgMembership) *OrgMembershipDeleteOne {
-	return c.DeleteOneID(om.ID)
+func (c *OrgMembershipClient) DeleteOne(_m *OrgMembership) *OrgMembershipDeleteOne {
+	return c.DeleteOneID(_m.ID)
 }
 
 // DeleteOneID returns a builder for deleting the given entity by its id.
@@ -316,16 +316,16 @@ func (c *OrgMembershipClient) GetX(ctx context.Context, id string) *OrgMembershi
 }
 
 // QueryOrganization queries the organization edge of a OrgMembership.
-func (c *OrgMembershipClient) QueryOrganization(om *OrgMembership) *OrganizationQuery {
+func (c *OrgMembershipClient) QueryOrganization(_m *OrgMembership) *OrganizationQuery {
 	query := (&OrganizationClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := om.ID
+		id := _m.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(orgmembership.Table, orgmembership.FieldID, id),
 			sqlgraph.To(organization.Table, organization.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, orgmembership.OrganizationTable, orgmembership.OrganizationColumn),
 		)
-		fromV = sqlgraph.Neighbors(om.driver.Dialect(), step)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
 		return fromV, nil
 	}
 	return query
@@ -411,8 +411,8 @@ func (c *OrganizationClient) Update() *OrganizationUpdate {
 }
 
 // UpdateOne returns an update builder for the given entity.
-func (c *OrganizationClient) UpdateOne(o *Organization) *OrganizationUpdateOne {
-	mutation := newOrganizationMutation(c.config, OpUpdateOne, withOrganization(o))
+func (c *OrganizationClient) UpdateOne(_m *Organization) *OrganizationUpdateOne {
+	mutation := newOrganizationMutation(c.config, OpUpdateOne, withOrganization(_m))
 	return &OrganizationUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
 }
 
@@ -429,8 +429,8 @@ func (c *OrganizationClient) Delete() *OrganizationDelete {
 }
 
 // DeleteOne returns a builder for deleting the given entity.
-func (c *OrganizationClient) DeleteOne(o *Organization) *OrganizationDeleteOne {
-	return c.DeleteOneID(o.ID)
+func (c *OrganizationClient) DeleteOne(_m *Organization) *OrganizationDeleteOne {
+	return c.DeleteOneID(_m.ID)
 }
 
 // DeleteOneID returns a builder for deleting the given entity by its id.

--- a/vanilla/_example/ent/ent.go
+++ b/vanilla/_example/ent/ent.go
@@ -71,14 +71,14 @@ var (
 )
 
 // checkColumn checks if the column exists in the given table.
-func checkColumn(table, column string) error {
+func checkColumn(t, c string) error {
 	initCheck.Do(func() {
 		columnCheck = sql.NewColumnCheck(map[string]func(string) bool{
 			orgmembership.Table: orgmembership.ValidColumn,
 			organization.Table:  organization.ValidColumn,
 		})
 	})
-	return columnCheck(table, column)
+	return columnCheck(t, c)
 }
 
 // Asc applies the given fields in ASC order.

--- a/vanilla/_example/ent/gql_collection.go
+++ b/vanilla/_example/ent/gql_collection.go
@@ -12,18 +12,18 @@ import (
 )
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
-func (om *OrgMembershipQuery) CollectFields(ctx context.Context, satisfies ...string) (*OrgMembershipQuery, error) {
+func (_q *OrgMembershipQuery) CollectFields(ctx context.Context, satisfies ...string) (*OrgMembershipQuery, error) {
 	fc := graphql.GetFieldContext(ctx)
 	if fc == nil {
-		return om, nil
+		return _q, nil
 	}
-	if err := om.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := _q.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
-	return om, nil
+	return _q, nil
 }
 
-func (om *OrgMembershipQuery) collectField(ctx context.Context, oneNode bool, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
+func (_q *OrgMembershipQuery) collectField(ctx context.Context, oneNode bool, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
 	var (
 		unknownSeen    bool
@@ -37,12 +37,12 @@ func (om *OrgMembershipQuery) collectField(ctx context.Context, oneNode bool, op
 			var (
 				alias = field.Alias
 				path  = append(path, alias)
-				query = (&OrganizationClient{config: om.config}).Query()
+				query = (&OrganizationClient{config: _q.config}).Query()
 			)
 			if err := query.collectField(ctx, oneNode, opCtx, field, path, mayAddCondition(satisfies, organizationImplementors)...); err != nil {
 				return err
 			}
-			om.withOrganization = query
+			_q.withOrganization = query
 			if _, ok := fieldSeen[orgmembership.FieldOrganizationID]; !ok {
 				selectedFields = append(selectedFields, orgmembership.FieldOrganizationID)
 				fieldSeen[orgmembership.FieldOrganizationID] = struct{}{}
@@ -69,7 +69,7 @@ func (om *OrgMembershipQuery) collectField(ctx context.Context, oneNode bool, op
 		}
 	}
 	if !unknownSeen {
-		om.Select(selectedFields...)
+		_q.Select(selectedFields...)
 	}
 	return nil
 }
@@ -104,18 +104,18 @@ func newOrgMembershipPaginateArgs(rv map[string]any) *orgmembershipPaginateArgs 
 }
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
-func (o *OrganizationQuery) CollectFields(ctx context.Context, satisfies ...string) (*OrganizationQuery, error) {
+func (_q *OrganizationQuery) CollectFields(ctx context.Context, satisfies ...string) (*OrganizationQuery, error) {
 	fc := graphql.GetFieldContext(ctx)
 	if fc == nil {
-		return o, nil
+		return _q, nil
 	}
-	if err := o.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := _q.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
-	return o, nil
+	return _q, nil
 }
 
-func (o *OrganizationQuery) collectField(ctx context.Context, oneNode bool, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
+func (_q *OrganizationQuery) collectField(ctx context.Context, oneNode bool, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
 	var (
 		unknownSeen    bool
@@ -166,7 +166,7 @@ func (o *OrganizationQuery) collectField(ctx context.Context, oneNode bool, opCt
 		}
 	}
 	if !unknownSeen {
-		o.Select(selectedFields...)
+		_q.Select(selectedFields...)
 	}
 	return nil
 }
@@ -247,7 +247,7 @@ func fieldArgs(ctx context.Context, whereInput any, path ...string) map[string]a
 func unmarshalArgs(ctx context.Context, whereInput any, args map[string]any) map[string]any {
 	for _, k := range []string{firstField, lastField} {
 		v, ok := args[k]
-		if !ok {
+		if !ok || v == nil {
 			continue
 		}
 		i, err := graphql.UnmarshalInt(v)

--- a/vanilla/_example/ent/gql_edge.go
+++ b/vanilla/_example/ent/gql_edge.go
@@ -6,10 +6,10 @@ import (
 	"context"
 )
 
-func (om *OrgMembership) Organization(ctx context.Context) (*Organization, error) {
-	result, err := om.Edges.OrganizationOrErr()
+func (_m *OrgMembership) Organization(ctx context.Context) (*Organization, error) {
+	result, err := _m.Edges.OrganizationOrErr()
 	if IsNotLoaded(err) {
-		result, err = om.QueryOrganization().Only(ctx)
+		result, err = _m.QueryOrganization().Only(ctx)
 	}
 	return result, err
 }

--- a/vanilla/_example/ent/gql_pagination.go
+++ b/vanilla/_example/ent/gql_pagination.go
@@ -208,8 +208,8 @@ func (p *orgmembershipPager) applyFilter(query *OrgMembershipQuery) (*OrgMembers
 	return query, nil
 }
 
-func (p *orgmembershipPager) toCursor(om *OrgMembership) Cursor {
-	return p.order.Field.toCursor(om)
+func (p *orgmembershipPager) toCursor(_m *OrgMembership) Cursor {
+	return p.order.Field.toCursor(_m)
 }
 
 func (p *orgmembershipPager) applyCursors(query *OrgMembershipQuery, after, before *Cursor) (*OrgMembershipQuery, error) {
@@ -255,7 +255,7 @@ func (p *orgmembershipPager) orderExpr(query *OrgMembershipQuery) sql.Querier {
 }
 
 // Paginate executes the query and returns a relay based cursor connection to OrgMembership.
-func (om *OrgMembershipQuery) Paginate(
+func (_m *OrgMembershipQuery) Paginate(
 	ctx context.Context, after *Cursor, first *int,
 	before *Cursor, last *int, opts ...OrgMembershipPaginateOption,
 ) (*OrgMembershipConnection, error) {
@@ -266,7 +266,7 @@ func (om *OrgMembershipQuery) Paginate(
 	if err != nil {
 		return nil, err
 	}
-	if om, err = pager.applyFilter(om); err != nil {
+	if _m, err = pager.applyFilter(_m); err != nil {
 		return nil, err
 	}
 	conn := &OrgMembershipConnection{Edges: []*OrgMembershipEdge{}}
@@ -274,7 +274,7 @@ func (om *OrgMembershipQuery) Paginate(
 	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
-			c := om.Clone()
+			c := _m.Clone()
 			c.ctx.Fields = nil
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
@@ -286,20 +286,20 @@ func (om *OrgMembershipQuery) Paginate(
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
 		return conn, nil
 	}
-	if om, err = pager.applyCursors(om, after, before); err != nil {
+	if _m, err = pager.applyCursors(_m, after, before); err != nil {
 		return nil, err
 	}
 	limit := paginateLimit(first, last)
 	if limit != 0 {
-		om.Limit(limit)
+		_m.Limit(limit)
 	}
 	if field := collectedField(ctx, edgesField, nodeField); field != nil {
-		if err := om.collectField(ctx, limit == 1, graphql.GetOperationContext(ctx), *field, []string{edgesField, nodeField}); err != nil {
+		if err := _m.collectField(ctx, limit == 1, graphql.GetOperationContext(ctx), *field, []string{edgesField, nodeField}); err != nil {
 			return nil, err
 		}
 	}
-	om = pager.applyOrder(om)
-	nodes, err := om.All(ctx)
+	_m = pager.applyOrder(_m)
+	nodes, err := _m.All(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -326,25 +326,25 @@ type OrgMembershipOrder struct {
 var DefaultOrgMembershipOrder = &OrgMembershipOrder{
 	Direction: entgql.OrderDirectionAsc,
 	Field: &OrgMembershipOrderField{
-		Value: func(om *OrgMembership) (ent.Value, error) {
-			return om.ID, nil
+		Value: func(_m *OrgMembership) (ent.Value, error) {
+			return _m.ID, nil
 		},
 		column: orgmembership.FieldID,
 		toTerm: orgmembership.ByID,
-		toCursor: func(om *OrgMembership) Cursor {
-			return Cursor{ID: om.ID}
+		toCursor: func(_m *OrgMembership) Cursor {
+			return Cursor{ID: _m.ID}
 		},
 	},
 }
 
 // ToEdge converts OrgMembership into OrgMembershipEdge.
-func (om *OrgMembership) ToEdge(order *OrgMembershipOrder) *OrgMembershipEdge {
+func (_m *OrgMembership) ToEdge(order *OrgMembershipOrder) *OrgMembershipEdge {
 	if order == nil {
 		order = DefaultOrgMembershipOrder
 	}
 	return &OrgMembershipEdge{
-		Node:   om,
-		Cursor: order.Field.toCursor(om),
+		Node:   _m,
+		Cursor: order.Field.toCursor(_m),
 	}
 }
 
@@ -457,8 +457,8 @@ func (p *organizationPager) applyFilter(query *OrganizationQuery) (*Organization
 	return query, nil
 }
 
-func (p *organizationPager) toCursor(o *Organization) Cursor {
-	return p.order.Field.toCursor(o)
+func (p *organizationPager) toCursor(_m *Organization) Cursor {
+	return p.order.Field.toCursor(_m)
 }
 
 func (p *organizationPager) applyCursors(query *OrganizationQuery, after, before *Cursor) (*OrganizationQuery, error) {
@@ -504,7 +504,7 @@ func (p *organizationPager) orderExpr(query *OrganizationQuery) sql.Querier {
 }
 
 // Paginate executes the query and returns a relay based cursor connection to Organization.
-func (o *OrganizationQuery) Paginate(
+func (_m *OrganizationQuery) Paginate(
 	ctx context.Context, after *Cursor, first *int,
 	before *Cursor, last *int, opts ...OrganizationPaginateOption,
 ) (*OrganizationConnection, error) {
@@ -515,7 +515,7 @@ func (o *OrganizationQuery) Paginate(
 	if err != nil {
 		return nil, err
 	}
-	if o, err = pager.applyFilter(o); err != nil {
+	if _m, err = pager.applyFilter(_m); err != nil {
 		return nil, err
 	}
 	conn := &OrganizationConnection{Edges: []*OrganizationEdge{}}
@@ -523,7 +523,7 @@ func (o *OrganizationQuery) Paginate(
 	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
-			c := o.Clone()
+			c := _m.Clone()
 			c.ctx.Fields = nil
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
@@ -535,20 +535,20 @@ func (o *OrganizationQuery) Paginate(
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
 		return conn, nil
 	}
-	if o, err = pager.applyCursors(o, after, before); err != nil {
+	if _m, err = pager.applyCursors(_m, after, before); err != nil {
 		return nil, err
 	}
 	limit := paginateLimit(first, last)
 	if limit != 0 {
-		o.Limit(limit)
+		_m.Limit(limit)
 	}
 	if field := collectedField(ctx, edgesField, nodeField); field != nil {
-		if err := o.collectField(ctx, limit == 1, graphql.GetOperationContext(ctx), *field, []string{edgesField, nodeField}); err != nil {
+		if err := _m.collectField(ctx, limit == 1, graphql.GetOperationContext(ctx), *field, []string{edgesField, nodeField}); err != nil {
 			return nil, err
 		}
 	}
-	o = pager.applyOrder(o)
-	nodes, err := o.All(ctx)
+	_m = pager.applyOrder(_m)
+	nodes, err := _m.All(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -559,29 +559,29 @@ func (o *OrganizationQuery) Paginate(
 var (
 	// OrganizationOrderFieldCreatedAt orders Organization by created_at.
 	OrganizationOrderFieldCreatedAt = &OrganizationOrderField{
-		Value: func(o *Organization) (ent.Value, error) {
-			return o.CreatedAt, nil
+		Value: func(_m *Organization) (ent.Value, error) {
+			return _m.CreatedAt, nil
 		},
 		column: organization.FieldCreatedAt,
 		toTerm: organization.ByCreatedAt,
-		toCursor: func(o *Organization) Cursor {
+		toCursor: func(_m *Organization) Cursor {
 			return Cursor{
-				ID:    o.ID,
-				Value: o.CreatedAt,
+				ID:    _m.ID,
+				Value: _m.CreatedAt,
 			}
 		},
 	}
 	// OrganizationOrderFieldUpdatedAt orders Organization by updated_at.
 	OrganizationOrderFieldUpdatedAt = &OrganizationOrderField{
-		Value: func(o *Organization) (ent.Value, error) {
-			return o.UpdatedAt, nil
+		Value: func(_m *Organization) (ent.Value, error) {
+			return _m.UpdatedAt, nil
 		},
 		column: organization.FieldUpdatedAt,
 		toTerm: organization.ByUpdatedAt,
-		toCursor: func(o *Organization) Cursor {
+		toCursor: func(_m *Organization) Cursor {
 			return Cursor{
-				ID:    o.ID,
-				Value: o.UpdatedAt,
+				ID:    _m.ID,
+				Value: _m.UpdatedAt,
 			}
 		},
 	}
@@ -640,24 +640,24 @@ type OrganizationOrder struct {
 var DefaultOrganizationOrder = &OrganizationOrder{
 	Direction: entgql.OrderDirectionAsc,
 	Field: &OrganizationOrderField{
-		Value: func(o *Organization) (ent.Value, error) {
-			return o.ID, nil
+		Value: func(_m *Organization) (ent.Value, error) {
+			return _m.ID, nil
 		},
 		column: organization.FieldID,
 		toTerm: organization.ByID,
-		toCursor: func(o *Organization) Cursor {
-			return Cursor{ID: o.ID}
+		toCursor: func(_m *Organization) Cursor {
+			return Cursor{ID: _m.ID}
 		},
 	},
 }
 
 // ToEdge converts Organization into OrganizationEdge.
-func (o *Organization) ToEdge(order *OrganizationOrder) *OrganizationEdge {
+func (_m *Organization) ToEdge(order *OrganizationOrder) *OrganizationEdge {
 	if order == nil {
 		order = DefaultOrganizationOrder
 	}
 	return &OrganizationEdge{
-		Node:   o,
-		Cursor: order.Field.toCursor(o),
+		Node:   _m,
+		Cursor: order.Field.toCursor(_m),
 	}
 }

--- a/vanilla/_example/ent/organization.go
+++ b/vanilla/_example/ent/organization.go
@@ -52,7 +52,7 @@ func (*Organization) scanValues(columns []string) ([]any, error) {
 
 // assignValues assigns the values that were returned from sql.Rows (after scanning)
 // to the Organization fields.
-func (o *Organization) assignValues(columns []string, values []any) error {
+func (_m *Organization) assignValues(columns []string, values []any) error {
 	if m, n := len(values), len(columns); m < n {
 		return fmt.Errorf("mismatch number of scan values: %d != %d", m, n)
 	}
@@ -62,52 +62,52 @@ func (o *Organization) assignValues(columns []string, values []any) error {
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field id", values[i])
 			} else if value.Valid {
-				o.ID = value.String
+				_m.ID = value.String
 			}
 		case organization.FieldDisplayID:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field display_id", values[i])
 			} else if value.Valid {
-				o.DisplayID = value.String
+				_m.DisplayID = value.String
 			}
 		case organization.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field created_at", values[i])
 			} else if value.Valid {
-				o.CreatedAt = value.Time
+				_m.CreatedAt = value.Time
 			}
 		case organization.FieldUpdatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field updated_at", values[i])
 			} else if value.Valid {
-				o.UpdatedAt = value.Time
+				_m.UpdatedAt = value.Time
 			}
 		case organization.FieldCreatedBy:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field created_by", values[i])
 			} else if value.Valid {
-				o.CreatedBy = value.String
+				_m.CreatedBy = value.String
 			}
 		case organization.FieldUpdatedBy:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field updated_by", values[i])
 			} else if value.Valid {
-				o.UpdatedBy = value.String
+				_m.UpdatedBy = value.String
 			}
 		case organization.FieldName:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field name", values[i])
 			} else if value.Valid {
-				o.Name = value.String
+				_m.Name = value.String
 			}
 		case organization.FieldDescription:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field description", values[i])
 			} else if value.Valid {
-				o.Description = value.String
+				_m.Description = value.String
 			}
 		default:
-			o.selectValues.Set(columns[i], values[i])
+			_m.selectValues.Set(columns[i], values[i])
 		}
 	}
 	return nil
@@ -115,53 +115,53 @@ func (o *Organization) assignValues(columns []string, values []any) error {
 
 // Value returns the ent.Value that was dynamically selected and assigned to the Organization.
 // This includes values selected through modifiers, order, etc.
-func (o *Organization) Value(name string) (ent.Value, error) {
-	return o.selectValues.Get(name)
+func (_m *Organization) Value(name string) (ent.Value, error) {
+	return _m.selectValues.Get(name)
 }
 
 // Update returns a builder for updating this Organization.
 // Note that you need to call Organization.Unwrap() before calling this method if this Organization
 // was returned from a transaction, and the transaction was committed or rolled back.
-func (o *Organization) Update() *OrganizationUpdateOne {
-	return NewOrganizationClient(o.config).UpdateOne(o)
+func (_m *Organization) Update() *OrganizationUpdateOne {
+	return NewOrganizationClient(_m.config).UpdateOne(_m)
 }
 
 // Unwrap unwraps the Organization entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
-func (o *Organization) Unwrap() *Organization {
-	_tx, ok := o.config.driver.(*txDriver)
+func (_m *Organization) Unwrap() *Organization {
+	_tx, ok := _m.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Organization is not a transactional entity")
 	}
-	o.config.driver = _tx.drv
-	return o
+	_m.config.driver = _tx.drv
+	return _m
 }
 
 // String implements the fmt.Stringer.
-func (o *Organization) String() string {
+func (_m *Organization) String() string {
 	var builder strings.Builder
 	builder.WriteString("Organization(")
-	builder.WriteString(fmt.Sprintf("id=%v, ", o.ID))
+	builder.WriteString(fmt.Sprintf("id=%v, ", _m.ID))
 	builder.WriteString("display_id=")
-	builder.WriteString(o.DisplayID)
+	builder.WriteString(_m.DisplayID)
 	builder.WriteString(", ")
 	builder.WriteString("created_at=")
-	builder.WriteString(o.CreatedAt.Format(time.ANSIC))
+	builder.WriteString(_m.CreatedAt.Format(time.ANSIC))
 	builder.WriteString(", ")
 	builder.WriteString("updated_at=")
-	builder.WriteString(o.UpdatedAt.Format(time.ANSIC))
+	builder.WriteString(_m.UpdatedAt.Format(time.ANSIC))
 	builder.WriteString(", ")
 	builder.WriteString("created_by=")
-	builder.WriteString(o.CreatedBy)
+	builder.WriteString(_m.CreatedBy)
 	builder.WriteString(", ")
 	builder.WriteString("updated_by=")
-	builder.WriteString(o.UpdatedBy)
+	builder.WriteString(_m.UpdatedBy)
 	builder.WriteString(", ")
 	builder.WriteString("name=")
-	builder.WriteString(o.Name)
+	builder.WriteString(_m.Name)
 	builder.WriteString(", ")
 	builder.WriteString("description=")
-	builder.WriteString(o.Description)
+	builder.WriteString(_m.Description)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/vanilla/_example/ent/organization_create.go
+++ b/vanilla/_example/ent/organization_create.go
@@ -21,117 +21,117 @@ type OrganizationCreate struct {
 }
 
 // SetDisplayID sets the "display_id" field.
-func (oc *OrganizationCreate) SetDisplayID(s string) *OrganizationCreate {
-	oc.mutation.SetDisplayID(s)
-	return oc
+func (_c *OrganizationCreate) SetDisplayID(v string) *OrganizationCreate {
+	_c.mutation.SetDisplayID(v)
+	return _c
 }
 
 // SetCreatedAt sets the "created_at" field.
-func (oc *OrganizationCreate) SetCreatedAt(t time.Time) *OrganizationCreate {
-	oc.mutation.SetCreatedAt(t)
-	return oc
+func (_c *OrganizationCreate) SetCreatedAt(v time.Time) *OrganizationCreate {
+	_c.mutation.SetCreatedAt(v)
+	return _c
 }
 
 // SetNillableCreatedAt sets the "created_at" field if the given value is not nil.
-func (oc *OrganizationCreate) SetNillableCreatedAt(t *time.Time) *OrganizationCreate {
-	if t != nil {
-		oc.SetCreatedAt(*t)
+func (_c *OrganizationCreate) SetNillableCreatedAt(v *time.Time) *OrganizationCreate {
+	if v != nil {
+		_c.SetCreatedAt(*v)
 	}
-	return oc
+	return _c
 }
 
 // SetUpdatedAt sets the "updated_at" field.
-func (oc *OrganizationCreate) SetUpdatedAt(t time.Time) *OrganizationCreate {
-	oc.mutation.SetUpdatedAt(t)
-	return oc
+func (_c *OrganizationCreate) SetUpdatedAt(v time.Time) *OrganizationCreate {
+	_c.mutation.SetUpdatedAt(v)
+	return _c
 }
 
 // SetNillableUpdatedAt sets the "updated_at" field if the given value is not nil.
-func (oc *OrganizationCreate) SetNillableUpdatedAt(t *time.Time) *OrganizationCreate {
-	if t != nil {
-		oc.SetUpdatedAt(*t)
+func (_c *OrganizationCreate) SetNillableUpdatedAt(v *time.Time) *OrganizationCreate {
+	if v != nil {
+		_c.SetUpdatedAt(*v)
 	}
-	return oc
+	return _c
 }
 
 // SetCreatedBy sets the "created_by" field.
-func (oc *OrganizationCreate) SetCreatedBy(s string) *OrganizationCreate {
-	oc.mutation.SetCreatedBy(s)
-	return oc
+func (_c *OrganizationCreate) SetCreatedBy(v string) *OrganizationCreate {
+	_c.mutation.SetCreatedBy(v)
+	return _c
 }
 
 // SetNillableCreatedBy sets the "created_by" field if the given value is not nil.
-func (oc *OrganizationCreate) SetNillableCreatedBy(s *string) *OrganizationCreate {
-	if s != nil {
-		oc.SetCreatedBy(*s)
+func (_c *OrganizationCreate) SetNillableCreatedBy(v *string) *OrganizationCreate {
+	if v != nil {
+		_c.SetCreatedBy(*v)
 	}
-	return oc
+	return _c
 }
 
 // SetUpdatedBy sets the "updated_by" field.
-func (oc *OrganizationCreate) SetUpdatedBy(s string) *OrganizationCreate {
-	oc.mutation.SetUpdatedBy(s)
-	return oc
+func (_c *OrganizationCreate) SetUpdatedBy(v string) *OrganizationCreate {
+	_c.mutation.SetUpdatedBy(v)
+	return _c
 }
 
 // SetNillableUpdatedBy sets the "updated_by" field if the given value is not nil.
-func (oc *OrganizationCreate) SetNillableUpdatedBy(s *string) *OrganizationCreate {
-	if s != nil {
-		oc.SetUpdatedBy(*s)
+func (_c *OrganizationCreate) SetNillableUpdatedBy(v *string) *OrganizationCreate {
+	if v != nil {
+		_c.SetUpdatedBy(*v)
 	}
-	return oc
+	return _c
 }
 
 // SetName sets the "name" field.
-func (oc *OrganizationCreate) SetName(s string) *OrganizationCreate {
-	oc.mutation.SetName(s)
-	return oc
+func (_c *OrganizationCreate) SetName(v string) *OrganizationCreate {
+	_c.mutation.SetName(v)
+	return _c
 }
 
 // SetDescription sets the "description" field.
-func (oc *OrganizationCreate) SetDescription(s string) *OrganizationCreate {
-	oc.mutation.SetDescription(s)
-	return oc
+func (_c *OrganizationCreate) SetDescription(v string) *OrganizationCreate {
+	_c.mutation.SetDescription(v)
+	return _c
 }
 
 // SetNillableDescription sets the "description" field if the given value is not nil.
-func (oc *OrganizationCreate) SetNillableDescription(s *string) *OrganizationCreate {
-	if s != nil {
-		oc.SetDescription(*s)
+func (_c *OrganizationCreate) SetNillableDescription(v *string) *OrganizationCreate {
+	if v != nil {
+		_c.SetDescription(*v)
 	}
-	return oc
+	return _c
 }
 
 // SetID sets the "id" field.
-func (oc *OrganizationCreate) SetID(s string) *OrganizationCreate {
-	oc.mutation.SetID(s)
-	return oc
+func (_c *OrganizationCreate) SetID(v string) *OrganizationCreate {
+	_c.mutation.SetID(v)
+	return _c
 }
 
 // SetNillableID sets the "id" field if the given value is not nil.
-func (oc *OrganizationCreate) SetNillableID(s *string) *OrganizationCreate {
-	if s != nil {
-		oc.SetID(*s)
+func (_c *OrganizationCreate) SetNillableID(v *string) *OrganizationCreate {
+	if v != nil {
+		_c.SetID(*v)
 	}
-	return oc
+	return _c
 }
 
 // Mutation returns the OrganizationMutation object of the builder.
-func (oc *OrganizationCreate) Mutation() *OrganizationMutation {
-	return oc.mutation
+func (_c *OrganizationCreate) Mutation() *OrganizationMutation {
+	return _c.mutation
 }
 
 // Save creates the Organization in the database.
-func (oc *OrganizationCreate) Save(ctx context.Context) (*Organization, error) {
-	if err := oc.defaults(); err != nil {
+func (_c *OrganizationCreate) Save(ctx context.Context) (*Organization, error) {
+	if err := _c.defaults(); err != nil {
 		return nil, err
 	}
-	return withHooks(ctx, oc.sqlSave, oc.mutation, oc.hooks)
+	return withHooks(ctx, _c.sqlSave, _c.mutation, _c.hooks)
 }
 
 // SaveX calls Save and panics if Save returns an error.
-func (oc *OrganizationCreate) SaveX(ctx context.Context) *Organization {
-	v, err := oc.Save(ctx)
+func (_c *OrganizationCreate) SaveX(ctx context.Context) *Organization {
+	v, err := _c.Save(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -139,58 +139,58 @@ func (oc *OrganizationCreate) SaveX(ctx context.Context) *Organization {
 }
 
 // Exec executes the query.
-func (oc *OrganizationCreate) Exec(ctx context.Context) error {
-	_, err := oc.Save(ctx)
+func (_c *OrganizationCreate) Exec(ctx context.Context) error {
+	_, err := _c.Save(ctx)
 	return err
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (oc *OrganizationCreate) ExecX(ctx context.Context) {
-	if err := oc.Exec(ctx); err != nil {
+func (_c *OrganizationCreate) ExecX(ctx context.Context) {
+	if err := _c.Exec(ctx); err != nil {
 		panic(err)
 	}
 }
 
 // defaults sets the default values of the builder before save.
-func (oc *OrganizationCreate) defaults() error {
-	if _, ok := oc.mutation.CreatedAt(); !ok {
+func (_c *OrganizationCreate) defaults() error {
+	if _, ok := _c.mutation.CreatedAt(); !ok {
 		if organization.DefaultCreatedAt == nil {
 			return fmt.Errorf("ent: uninitialized organization.DefaultCreatedAt (forgotten import ent/runtime?)")
 		}
 		v := organization.DefaultCreatedAt()
-		oc.mutation.SetCreatedAt(v)
+		_c.mutation.SetCreatedAt(v)
 	}
-	if _, ok := oc.mutation.UpdatedAt(); !ok {
+	if _, ok := _c.mutation.UpdatedAt(); !ok {
 		if organization.DefaultUpdatedAt == nil {
 			return fmt.Errorf("ent: uninitialized organization.DefaultUpdatedAt (forgotten import ent/runtime?)")
 		}
 		v := organization.DefaultUpdatedAt()
-		oc.mutation.SetUpdatedAt(v)
+		_c.mutation.SetUpdatedAt(v)
 	}
-	if _, ok := oc.mutation.ID(); !ok {
+	if _, ok := _c.mutation.ID(); !ok {
 		if organization.DefaultID == nil {
 			return fmt.Errorf("ent: uninitialized organization.DefaultID (forgotten import ent/runtime?)")
 		}
 		v := organization.DefaultID()
-		oc.mutation.SetID(v)
+		_c.mutation.SetID(v)
 	}
 	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
-func (oc *OrganizationCreate) check() error {
-	if _, ok := oc.mutation.DisplayID(); !ok {
+func (_c *OrganizationCreate) check() error {
+	if _, ok := _c.mutation.DisplayID(); !ok {
 		return &ValidationError{Name: "display_id", err: errors.New(`ent: missing required field "Organization.display_id"`)}
 	}
-	if v, ok := oc.mutation.DisplayID(); ok {
+	if v, ok := _c.mutation.DisplayID(); ok {
 		if err := organization.DisplayIDValidator(v); err != nil {
 			return &ValidationError{Name: "display_id", err: fmt.Errorf(`ent: validator failed for field "Organization.display_id": %w`, err)}
 		}
 	}
-	if _, ok := oc.mutation.Name(); !ok {
+	if _, ok := _c.mutation.Name(); !ok {
 		return &ValidationError{Name: "name", err: errors.New(`ent: missing required field "Organization.name"`)}
 	}
-	if v, ok := oc.mutation.Name(); ok {
+	if v, ok := _c.mutation.Name(); ok {
 		if err := organization.NameValidator(v); err != nil {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Organization.name": %w`, err)}
 		}
@@ -198,12 +198,12 @@ func (oc *OrganizationCreate) check() error {
 	return nil
 }
 
-func (oc *OrganizationCreate) sqlSave(ctx context.Context) (*Organization, error) {
-	if err := oc.check(); err != nil {
+func (_c *OrganizationCreate) sqlSave(ctx context.Context) (*Organization, error) {
+	if err := _c.check(); err != nil {
 		return nil, err
 	}
-	_node, _spec := oc.createSpec()
-	if err := sqlgraph.CreateNode(ctx, oc.driver, _spec); err != nil {
+	_node, _spec := _c.createSpec()
+	if err := sqlgraph.CreateNode(ctx, _c.driver, _spec); err != nil {
 		if sqlgraph.IsConstraintError(err) {
 			err = &ConstraintError{msg: err.Error(), wrap: err}
 		}
@@ -216,45 +216,45 @@ func (oc *OrganizationCreate) sqlSave(ctx context.Context) (*Organization, error
 			return nil, fmt.Errorf("unexpected Organization.ID type: %T", _spec.ID.Value)
 		}
 	}
-	oc.mutation.id = &_node.ID
-	oc.mutation.done = true
+	_c.mutation.id = &_node.ID
+	_c.mutation.done = true
 	return _node, nil
 }
 
-func (oc *OrganizationCreate) createSpec() (*Organization, *sqlgraph.CreateSpec) {
+func (_c *OrganizationCreate) createSpec() (*Organization, *sqlgraph.CreateSpec) {
 	var (
-		_node = &Organization{config: oc.config}
+		_node = &Organization{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(organization.Table, sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString))
 	)
-	if id, ok := oc.mutation.ID(); ok {
+	if id, ok := _c.mutation.ID(); ok {
 		_node.ID = id
 		_spec.ID.Value = id
 	}
-	if value, ok := oc.mutation.DisplayID(); ok {
+	if value, ok := _c.mutation.DisplayID(); ok {
 		_spec.SetField(organization.FieldDisplayID, field.TypeString, value)
 		_node.DisplayID = value
 	}
-	if value, ok := oc.mutation.CreatedAt(); ok {
+	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(organization.FieldCreatedAt, field.TypeTime, value)
 		_node.CreatedAt = value
 	}
-	if value, ok := oc.mutation.UpdatedAt(); ok {
+	if value, ok := _c.mutation.UpdatedAt(); ok {
 		_spec.SetField(organization.FieldUpdatedAt, field.TypeTime, value)
 		_node.UpdatedAt = value
 	}
-	if value, ok := oc.mutation.CreatedBy(); ok {
+	if value, ok := _c.mutation.CreatedBy(); ok {
 		_spec.SetField(organization.FieldCreatedBy, field.TypeString, value)
 		_node.CreatedBy = value
 	}
-	if value, ok := oc.mutation.UpdatedBy(); ok {
+	if value, ok := _c.mutation.UpdatedBy(); ok {
 		_spec.SetField(organization.FieldUpdatedBy, field.TypeString, value)
 		_node.UpdatedBy = value
 	}
-	if value, ok := oc.mutation.Name(); ok {
+	if value, ok := _c.mutation.Name(); ok {
 		_spec.SetField(organization.FieldName, field.TypeString, value)
 		_node.Name = value
 	}
-	if value, ok := oc.mutation.Description(); ok {
+	if value, ok := _c.mutation.Description(); ok {
 		_spec.SetField(organization.FieldDescription, field.TypeString, value)
 		_node.Description = value
 	}
@@ -269,16 +269,16 @@ type OrganizationCreateBulk struct {
 }
 
 // Save creates the Organization entities in the database.
-func (ocb *OrganizationCreateBulk) Save(ctx context.Context) ([]*Organization, error) {
-	if ocb.err != nil {
-		return nil, ocb.err
+func (_c *OrganizationCreateBulk) Save(ctx context.Context) ([]*Organization, error) {
+	if _c.err != nil {
+		return nil, _c.err
 	}
-	specs := make([]*sqlgraph.CreateSpec, len(ocb.builders))
-	nodes := make([]*Organization, len(ocb.builders))
-	mutators := make([]Mutator, len(ocb.builders))
-	for i := range ocb.builders {
+	specs := make([]*sqlgraph.CreateSpec, len(_c.builders))
+	nodes := make([]*Organization, len(_c.builders))
+	mutators := make([]Mutator, len(_c.builders))
+	for i := range _c.builders {
 		func(i int, root context.Context) {
-			builder := ocb.builders[i]
+			builder := _c.builders[i]
 			builder.defaults()
 			var mut Mutator = MutateFunc(func(ctx context.Context, m Mutation) (Value, error) {
 				mutation, ok := m.(*OrganizationMutation)
@@ -292,11 +292,11 @@ func (ocb *OrganizationCreateBulk) Save(ctx context.Context) ([]*Organization, e
 				var err error
 				nodes[i], specs[i] = builder.createSpec()
 				if i < len(mutators)-1 {
-					_, err = mutators[i+1].Mutate(root, ocb.builders[i+1].mutation)
+					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
 					// Invoke the actual operation on the latest mutation in the chain.
-					if err = sqlgraph.BatchCreate(ctx, ocb.driver, spec); err != nil {
+					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
 							err = &ConstraintError{msg: err.Error(), wrap: err}
 						}
@@ -316,7 +316,7 @@ func (ocb *OrganizationCreateBulk) Save(ctx context.Context) ([]*Organization, e
 		}(i, ctx)
 	}
 	if len(mutators) > 0 {
-		if _, err := mutators[0].Mutate(ctx, ocb.builders[0].mutation); err != nil {
+		if _, err := mutators[0].Mutate(ctx, _c.builders[0].mutation); err != nil {
 			return nil, err
 		}
 	}
@@ -324,8 +324,8 @@ func (ocb *OrganizationCreateBulk) Save(ctx context.Context) ([]*Organization, e
 }
 
 // SaveX is like Save, but panics if an error occurs.
-func (ocb *OrganizationCreateBulk) SaveX(ctx context.Context) []*Organization {
-	v, err := ocb.Save(ctx)
+func (_c *OrganizationCreateBulk) SaveX(ctx context.Context) []*Organization {
+	v, err := _c.Save(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -333,14 +333,14 @@ func (ocb *OrganizationCreateBulk) SaveX(ctx context.Context) []*Organization {
 }
 
 // Exec executes the query.
-func (ocb *OrganizationCreateBulk) Exec(ctx context.Context) error {
-	_, err := ocb.Save(ctx)
+func (_c *OrganizationCreateBulk) Exec(ctx context.Context) error {
+	_, err := _c.Save(ctx)
 	return err
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (ocb *OrganizationCreateBulk) ExecX(ctx context.Context) {
-	if err := ocb.Exec(ctx); err != nil {
+func (_c *OrganizationCreateBulk) ExecX(ctx context.Context) {
+	if err := _c.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/vanilla/_example/ent/organization_delete.go
+++ b/vanilla/_example/ent/organization_delete.go
@@ -20,56 +20,56 @@ type OrganizationDelete struct {
 }
 
 // Where appends a list predicates to the OrganizationDelete builder.
-func (od *OrganizationDelete) Where(ps ...predicate.Organization) *OrganizationDelete {
-	od.mutation.Where(ps...)
-	return od
+func (_d *OrganizationDelete) Where(ps ...predicate.Organization) *OrganizationDelete {
+	_d.mutation.Where(ps...)
+	return _d
 }
 
 // Exec executes the deletion query and returns how many vertices were deleted.
-func (od *OrganizationDelete) Exec(ctx context.Context) (int, error) {
-	return withHooks(ctx, od.sqlExec, od.mutation, od.hooks)
+func (_d *OrganizationDelete) Exec(ctx context.Context) (int, error) {
+	return withHooks(ctx, _d.sqlExec, _d.mutation, _d.hooks)
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (od *OrganizationDelete) ExecX(ctx context.Context) int {
-	n, err := od.Exec(ctx)
+func (_d *OrganizationDelete) ExecX(ctx context.Context) int {
+	n, err := _d.Exec(ctx)
 	if err != nil {
 		panic(err)
 	}
 	return n
 }
 
-func (od *OrganizationDelete) sqlExec(ctx context.Context) (int, error) {
+func (_d *OrganizationDelete) sqlExec(ctx context.Context) (int, error) {
 	_spec := sqlgraph.NewDeleteSpec(organization.Table, sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString))
-	if ps := od.mutation.predicates; len(ps) > 0 {
+	if ps := _d.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	affected, err := sqlgraph.DeleteNodes(ctx, od.driver, _spec)
+	affected, err := sqlgraph.DeleteNodes(ctx, _d.driver, _spec)
 	if err != nil && sqlgraph.IsConstraintError(err) {
 		err = &ConstraintError{msg: err.Error(), wrap: err}
 	}
-	od.mutation.done = true
+	_d.mutation.done = true
 	return affected, err
 }
 
 // OrganizationDeleteOne is the builder for deleting a single Organization entity.
 type OrganizationDeleteOne struct {
-	od *OrganizationDelete
+	_d *OrganizationDelete
 }
 
 // Where appends a list predicates to the OrganizationDelete builder.
-func (odo *OrganizationDeleteOne) Where(ps ...predicate.Organization) *OrganizationDeleteOne {
-	odo.od.mutation.Where(ps...)
-	return odo
+func (_d *OrganizationDeleteOne) Where(ps ...predicate.Organization) *OrganizationDeleteOne {
+	_d._d.mutation.Where(ps...)
+	return _d
 }
 
 // Exec executes the deletion query.
-func (odo *OrganizationDeleteOne) Exec(ctx context.Context) error {
-	n, err := odo.od.Exec(ctx)
+func (_d *OrganizationDeleteOne) Exec(ctx context.Context) error {
+	n, err := _d._d.Exec(ctx)
 	switch {
 	case err != nil:
 		return err
@@ -81,8 +81,8 @@ func (odo *OrganizationDeleteOne) Exec(ctx context.Context) error {
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (odo *OrganizationDeleteOne) ExecX(ctx context.Context) {
-	if err := odo.Exec(ctx); err != nil {
+func (_d *OrganizationDeleteOne) ExecX(ctx context.Context) {
+	if err := _d.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/vanilla/_example/ent/organization_query.go
+++ b/vanilla/_example/ent/organization_query.go
@@ -30,40 +30,40 @@ type OrganizationQuery struct {
 }
 
 // Where adds a new predicate for the OrganizationQuery builder.
-func (oq *OrganizationQuery) Where(ps ...predicate.Organization) *OrganizationQuery {
-	oq.predicates = append(oq.predicates, ps...)
-	return oq
+func (_q *OrganizationQuery) Where(ps ...predicate.Organization) *OrganizationQuery {
+	_q.predicates = append(_q.predicates, ps...)
+	return _q
 }
 
 // Limit the number of records to be returned by this query.
-func (oq *OrganizationQuery) Limit(limit int) *OrganizationQuery {
-	oq.ctx.Limit = &limit
-	return oq
+func (_q *OrganizationQuery) Limit(limit int) *OrganizationQuery {
+	_q.ctx.Limit = &limit
+	return _q
 }
 
 // Offset to start from.
-func (oq *OrganizationQuery) Offset(offset int) *OrganizationQuery {
-	oq.ctx.Offset = &offset
-	return oq
+func (_q *OrganizationQuery) Offset(offset int) *OrganizationQuery {
+	_q.ctx.Offset = &offset
+	return _q
 }
 
 // Unique configures the query builder to filter duplicate records on query.
 // By default, unique is set to true, and can be disabled using this method.
-func (oq *OrganizationQuery) Unique(unique bool) *OrganizationQuery {
-	oq.ctx.Unique = &unique
-	return oq
+func (_q *OrganizationQuery) Unique(unique bool) *OrganizationQuery {
+	_q.ctx.Unique = &unique
+	return _q
 }
 
 // Order specifies how the records should be ordered.
-func (oq *OrganizationQuery) Order(o ...organization.OrderOption) *OrganizationQuery {
-	oq.order = append(oq.order, o...)
-	return oq
+func (_q *OrganizationQuery) Order(o ...organization.OrderOption) *OrganizationQuery {
+	_q.order = append(_q.order, o...)
+	return _q
 }
 
 // First returns the first Organization entity from the query.
 // Returns a *NotFoundError when no Organization was found.
-func (oq *OrganizationQuery) First(ctx context.Context) (*Organization, error) {
-	nodes, err := oq.Limit(1).All(setContextOp(ctx, oq.ctx, ent.OpQueryFirst))
+func (_q *OrganizationQuery) First(ctx context.Context) (*Organization, error) {
+	nodes, err := _q.Limit(1).All(setContextOp(ctx, _q.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +74,8 @@ func (oq *OrganizationQuery) First(ctx context.Context) (*Organization, error) {
 }
 
 // FirstX is like First, but panics if an error occurs.
-func (oq *OrganizationQuery) FirstX(ctx context.Context) *Organization {
-	node, err := oq.First(ctx)
+func (_q *OrganizationQuery) FirstX(ctx context.Context) *Organization {
+	node, err := _q.First(ctx)
 	if err != nil && !IsNotFound(err) {
 		panic(err)
 	}
@@ -84,9 +84,9 @@ func (oq *OrganizationQuery) FirstX(ctx context.Context) *Organization {
 
 // FirstID returns the first Organization ID from the query.
 // Returns a *NotFoundError when no Organization ID was found.
-func (oq *OrganizationQuery) FirstID(ctx context.Context) (id string, err error) {
+func (_q *OrganizationQuery) FirstID(ctx context.Context) (id string, err error) {
 	var ids []string
-	if ids, err = oq.Limit(1).IDs(setContextOp(ctx, oq.ctx, ent.OpQueryFirstID)); err != nil {
+	if ids, err = _q.Limit(1).IDs(setContextOp(ctx, _q.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -97,8 +97,8 @@ func (oq *OrganizationQuery) FirstID(ctx context.Context) (id string, err error)
 }
 
 // FirstIDX is like FirstID, but panics if an error occurs.
-func (oq *OrganizationQuery) FirstIDX(ctx context.Context) string {
-	id, err := oq.FirstID(ctx)
+func (_q *OrganizationQuery) FirstIDX(ctx context.Context) string {
+	id, err := _q.FirstID(ctx)
 	if err != nil && !IsNotFound(err) {
 		panic(err)
 	}
@@ -108,8 +108,8 @@ func (oq *OrganizationQuery) FirstIDX(ctx context.Context) string {
 // Only returns a single Organization entity found by the query, ensuring it only returns one.
 // Returns a *NotSingularError when more than one Organization entity is found.
 // Returns a *NotFoundError when no Organization entities are found.
-func (oq *OrganizationQuery) Only(ctx context.Context) (*Organization, error) {
-	nodes, err := oq.Limit(2).All(setContextOp(ctx, oq.ctx, ent.OpQueryOnly))
+func (_q *OrganizationQuery) Only(ctx context.Context) (*Organization, error) {
+	nodes, err := _q.Limit(2).All(setContextOp(ctx, _q.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -124,8 +124,8 @@ func (oq *OrganizationQuery) Only(ctx context.Context) (*Organization, error) {
 }
 
 // OnlyX is like Only, but panics if an error occurs.
-func (oq *OrganizationQuery) OnlyX(ctx context.Context) *Organization {
-	node, err := oq.Only(ctx)
+func (_q *OrganizationQuery) OnlyX(ctx context.Context) *Organization {
+	node, err := _q.Only(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -135,9 +135,9 @@ func (oq *OrganizationQuery) OnlyX(ctx context.Context) *Organization {
 // OnlyID is like Only, but returns the only Organization ID in the query.
 // Returns a *NotSingularError when more than one Organization ID is found.
 // Returns a *NotFoundError when no entities are found.
-func (oq *OrganizationQuery) OnlyID(ctx context.Context) (id string, err error) {
+func (_q *OrganizationQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string
-	if ids, err = oq.Limit(2).IDs(setContextOp(ctx, oq.ctx, ent.OpQueryOnlyID)); err != nil {
+	if ids, err = _q.Limit(2).IDs(setContextOp(ctx, _q.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -152,8 +152,8 @@ func (oq *OrganizationQuery) OnlyID(ctx context.Context) (id string, err error) 
 }
 
 // OnlyIDX is like OnlyID, but panics if an error occurs.
-func (oq *OrganizationQuery) OnlyIDX(ctx context.Context) string {
-	id, err := oq.OnlyID(ctx)
+func (_q *OrganizationQuery) OnlyIDX(ctx context.Context) string {
+	id, err := _q.OnlyID(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -161,18 +161,18 @@ func (oq *OrganizationQuery) OnlyIDX(ctx context.Context) string {
 }
 
 // All executes the query and returns a list of Organizations.
-func (oq *OrganizationQuery) All(ctx context.Context) ([]*Organization, error) {
-	ctx = setContextOp(ctx, oq.ctx, ent.OpQueryAll)
-	if err := oq.prepareQuery(ctx); err != nil {
+func (_q *OrganizationQuery) All(ctx context.Context) ([]*Organization, error) {
+	ctx = setContextOp(ctx, _q.ctx, ent.OpQueryAll)
+	if err := _q.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
 	qr := querierAll[[]*Organization, *OrganizationQuery]()
-	return withInterceptors[[]*Organization](ctx, oq, qr, oq.inters)
+	return withInterceptors[[]*Organization](ctx, _q, qr, _q.inters)
 }
 
 // AllX is like All, but panics if an error occurs.
-func (oq *OrganizationQuery) AllX(ctx context.Context) []*Organization {
-	nodes, err := oq.All(ctx)
+func (_q *OrganizationQuery) AllX(ctx context.Context) []*Organization {
+	nodes, err := _q.All(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -180,20 +180,20 @@ func (oq *OrganizationQuery) AllX(ctx context.Context) []*Organization {
 }
 
 // IDs executes the query and returns a list of Organization IDs.
-func (oq *OrganizationQuery) IDs(ctx context.Context) (ids []string, err error) {
-	if oq.ctx.Unique == nil && oq.path != nil {
-		oq.Unique(true)
+func (_q *OrganizationQuery) IDs(ctx context.Context) (ids []string, err error) {
+	if _q.ctx.Unique == nil && _q.path != nil {
+		_q.Unique(true)
 	}
-	ctx = setContextOp(ctx, oq.ctx, ent.OpQueryIDs)
-	if err = oq.Select(organization.FieldID).Scan(ctx, &ids); err != nil {
+	ctx = setContextOp(ctx, _q.ctx, ent.OpQueryIDs)
+	if err = _q.Select(organization.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
 	return ids, nil
 }
 
 // IDsX is like IDs, but panics if an error occurs.
-func (oq *OrganizationQuery) IDsX(ctx context.Context) []string {
-	ids, err := oq.IDs(ctx)
+func (_q *OrganizationQuery) IDsX(ctx context.Context) []string {
+	ids, err := _q.IDs(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -201,17 +201,17 @@ func (oq *OrganizationQuery) IDsX(ctx context.Context) []string {
 }
 
 // Count returns the count of the given query.
-func (oq *OrganizationQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, oq.ctx, ent.OpQueryCount)
-	if err := oq.prepareQuery(ctx); err != nil {
+func (_q *OrganizationQuery) Count(ctx context.Context) (int, error) {
+	ctx = setContextOp(ctx, _q.ctx, ent.OpQueryCount)
+	if err := _q.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
-	return withInterceptors[int](ctx, oq, querierCount[*OrganizationQuery](), oq.inters)
+	return withInterceptors[int](ctx, _q, querierCount[*OrganizationQuery](), _q.inters)
 }
 
 // CountX is like Count, but panics if an error occurs.
-func (oq *OrganizationQuery) CountX(ctx context.Context) int {
-	count, err := oq.Count(ctx)
+func (_q *OrganizationQuery) CountX(ctx context.Context) int {
+	count, err := _q.Count(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -219,9 +219,9 @@ func (oq *OrganizationQuery) CountX(ctx context.Context) int {
 }
 
 // Exist returns true if the query has elements in the graph.
-func (oq *OrganizationQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, oq.ctx, ent.OpQueryExist)
-	switch _, err := oq.FirstID(ctx); {
+func (_q *OrganizationQuery) Exist(ctx context.Context) (bool, error) {
+	ctx = setContextOp(ctx, _q.ctx, ent.OpQueryExist)
+	switch _, err := _q.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
 	case err != nil:
@@ -232,8 +232,8 @@ func (oq *OrganizationQuery) Exist(ctx context.Context) (bool, error) {
 }
 
 // ExistX is like Exist, but panics if an error occurs.
-func (oq *OrganizationQuery) ExistX(ctx context.Context) bool {
-	exist, err := oq.Exist(ctx)
+func (_q *OrganizationQuery) ExistX(ctx context.Context) bool {
+	exist, err := _q.Exist(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -242,19 +242,19 @@ func (oq *OrganizationQuery) ExistX(ctx context.Context) bool {
 
 // Clone returns a duplicate of the OrganizationQuery builder, including all associated steps. It can be
 // used to prepare common query builders and use them differently after the clone is made.
-func (oq *OrganizationQuery) Clone() *OrganizationQuery {
-	if oq == nil {
+func (_q *OrganizationQuery) Clone() *OrganizationQuery {
+	if _q == nil {
 		return nil
 	}
 	return &OrganizationQuery{
-		config:     oq.config,
-		ctx:        oq.ctx.Clone(),
-		order:      append([]organization.OrderOption{}, oq.order...),
-		inters:     append([]Interceptor{}, oq.inters...),
-		predicates: append([]predicate.Organization{}, oq.predicates...),
+		config:     _q.config,
+		ctx:        _q.ctx.Clone(),
+		order:      append([]organization.OrderOption{}, _q.order...),
+		inters:     append([]Interceptor{}, _q.inters...),
+		predicates: append([]predicate.Organization{}, _q.predicates...),
 		// clone intermediate query.
-		sql:  oq.sql.Clone(),
-		path: oq.path,
+		sql:  _q.sql.Clone(),
+		path: _q.path,
 	}
 }
 
@@ -272,10 +272,10 @@ func (oq *OrganizationQuery) Clone() *OrganizationQuery {
 //		GroupBy(organization.FieldDisplayID).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
-func (oq *OrganizationQuery) GroupBy(field string, fields ...string) *OrganizationGroupBy {
-	oq.ctx.Fields = append([]string{field}, fields...)
-	grbuild := &OrganizationGroupBy{build: oq}
-	grbuild.flds = &oq.ctx.Fields
+func (_q *OrganizationQuery) GroupBy(field string, fields ...string) *OrganizationGroupBy {
+	_q.ctx.Fields = append([]string{field}, fields...)
+	grbuild := &OrganizationGroupBy{build: _q}
+	grbuild.flds = &_q.ctx.Fields
 	grbuild.label = organization.Label
 	grbuild.scan = grbuild.Scan
 	return grbuild
@@ -293,99 +293,99 @@ func (oq *OrganizationQuery) GroupBy(field string, fields ...string) *Organizati
 //	client.Organization.Query().
 //		Select(organization.FieldDisplayID).
 //		Scan(ctx, &v)
-func (oq *OrganizationQuery) Select(fields ...string) *OrganizationSelect {
-	oq.ctx.Fields = append(oq.ctx.Fields, fields...)
-	sbuild := &OrganizationSelect{OrganizationQuery: oq}
+func (_q *OrganizationQuery) Select(fields ...string) *OrganizationSelect {
+	_q.ctx.Fields = append(_q.ctx.Fields, fields...)
+	sbuild := &OrganizationSelect{OrganizationQuery: _q}
 	sbuild.label = organization.Label
-	sbuild.flds, sbuild.scan = &oq.ctx.Fields, sbuild.Scan
+	sbuild.flds, sbuild.scan = &_q.ctx.Fields, sbuild.Scan
 	return sbuild
 }
 
 // Aggregate returns a OrganizationSelect configured with the given aggregations.
-func (oq *OrganizationQuery) Aggregate(fns ...AggregateFunc) *OrganizationSelect {
-	return oq.Select().Aggregate(fns...)
+func (_q *OrganizationQuery) Aggregate(fns ...AggregateFunc) *OrganizationSelect {
+	return _q.Select().Aggregate(fns...)
 }
 
-func (oq *OrganizationQuery) prepareQuery(ctx context.Context) error {
-	for _, inter := range oq.inters {
+func (_q *OrganizationQuery) prepareQuery(ctx context.Context) error {
+	for _, inter := range _q.inters {
 		if inter == nil {
 			return fmt.Errorf("ent: uninitialized interceptor (forgotten import ent/runtime?)")
 		}
 		if trv, ok := inter.(Traverser); ok {
-			if err := trv.Traverse(ctx, oq); err != nil {
+			if err := trv.Traverse(ctx, _q); err != nil {
 				return err
 			}
 		}
 	}
-	for _, f := range oq.ctx.Fields {
+	for _, f := range _q.ctx.Fields {
 		if !organization.ValidColumn(f) {
 			return &ValidationError{Name: f, err: fmt.Errorf("ent: invalid field %q for query", f)}
 		}
 	}
-	if oq.path != nil {
-		prev, err := oq.path(ctx)
+	if _q.path != nil {
+		prev, err := _q.path(ctx)
 		if err != nil {
 			return err
 		}
-		oq.sql = prev
+		_q.sql = prev
 	}
 	return nil
 }
 
-func (oq *OrganizationQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Organization, error) {
+func (_q *OrganizationQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Organization, error) {
 	var (
 		nodes = []*Organization{}
-		_spec = oq.querySpec()
+		_spec = _q.querySpec()
 	)
 	_spec.ScanValues = func(columns []string) ([]any, error) {
 		return (*Organization).scanValues(nil, columns)
 	}
 	_spec.Assign = func(columns []string, values []any) error {
-		node := &Organization{config: oq.config}
+		node := &Organization{config: _q.config}
 		nodes = append(nodes, node)
 		return node.assignValues(columns, values)
 	}
-	if len(oq.modifiers) > 0 {
-		_spec.Modifiers = oq.modifiers
+	if len(_q.modifiers) > 0 {
+		_spec.Modifiers = _q.modifiers
 	}
 	for i := range hooks {
 		hooks[i](ctx, _spec)
 	}
-	if err := sqlgraph.QueryNodes(ctx, oq.driver, _spec); err != nil {
+	if err := sqlgraph.QueryNodes(ctx, _q.driver, _spec); err != nil {
 		return nil, err
 	}
 	if len(nodes) == 0 {
 		return nodes, nil
 	}
-	for i := range oq.loadTotal {
-		if err := oq.loadTotal[i](ctx, nodes); err != nil {
+	for i := range _q.loadTotal {
+		if err := _q.loadTotal[i](ctx, nodes); err != nil {
 			return nil, err
 		}
 	}
 	return nodes, nil
 }
 
-func (oq *OrganizationQuery) sqlCount(ctx context.Context) (int, error) {
-	_spec := oq.querySpec()
-	if len(oq.modifiers) > 0 {
-		_spec.Modifiers = oq.modifiers
+func (_q *OrganizationQuery) sqlCount(ctx context.Context) (int, error) {
+	_spec := _q.querySpec()
+	if len(_q.modifiers) > 0 {
+		_spec.Modifiers = _q.modifiers
 	}
-	_spec.Node.Columns = oq.ctx.Fields
-	if len(oq.ctx.Fields) > 0 {
-		_spec.Unique = oq.ctx.Unique != nil && *oq.ctx.Unique
+	_spec.Node.Columns = _q.ctx.Fields
+	if len(_q.ctx.Fields) > 0 {
+		_spec.Unique = _q.ctx.Unique != nil && *_q.ctx.Unique
 	}
-	return sqlgraph.CountNodes(ctx, oq.driver, _spec)
+	return sqlgraph.CountNodes(ctx, _q.driver, _spec)
 }
 
-func (oq *OrganizationQuery) querySpec() *sqlgraph.QuerySpec {
+func (_q *OrganizationQuery) querySpec() *sqlgraph.QuerySpec {
 	_spec := sqlgraph.NewQuerySpec(organization.Table, organization.Columns, sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString))
-	_spec.From = oq.sql
-	if unique := oq.ctx.Unique; unique != nil {
+	_spec.From = _q.sql
+	if unique := _q.ctx.Unique; unique != nil {
 		_spec.Unique = *unique
-	} else if oq.path != nil {
+	} else if _q.path != nil {
 		_spec.Unique = true
 	}
-	if fields := oq.ctx.Fields; len(fields) > 0 {
+	if fields := _q.ctx.Fields; len(fields) > 0 {
 		_spec.Node.Columns = make([]string, 0, len(fields))
 		_spec.Node.Columns = append(_spec.Node.Columns, organization.FieldID)
 		for i := range fields {
@@ -394,20 +394,20 @@ func (oq *OrganizationQuery) querySpec() *sqlgraph.QuerySpec {
 			}
 		}
 	}
-	if ps := oq.predicates; len(ps) > 0 {
+	if ps := _q.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	if limit := oq.ctx.Limit; limit != nil {
+	if limit := _q.ctx.Limit; limit != nil {
 		_spec.Limit = *limit
 	}
-	if offset := oq.ctx.Offset; offset != nil {
+	if offset := _q.ctx.Offset; offset != nil {
 		_spec.Offset = *offset
 	}
-	if ps := oq.order; len(ps) > 0 {
+	if ps := _q.order; len(ps) > 0 {
 		_spec.Order = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
@@ -417,33 +417,33 @@ func (oq *OrganizationQuery) querySpec() *sqlgraph.QuerySpec {
 	return _spec
 }
 
-func (oq *OrganizationQuery) sqlQuery(ctx context.Context) *sql.Selector {
-	builder := sql.Dialect(oq.driver.Dialect())
+func (_q *OrganizationQuery) sqlQuery(ctx context.Context) *sql.Selector {
+	builder := sql.Dialect(_q.driver.Dialect())
 	t1 := builder.Table(organization.Table)
-	columns := oq.ctx.Fields
+	columns := _q.ctx.Fields
 	if len(columns) == 0 {
 		columns = organization.Columns
 	}
 	selector := builder.Select(t1.Columns(columns...)...).From(t1)
-	if oq.sql != nil {
-		selector = oq.sql
+	if _q.sql != nil {
+		selector = _q.sql
 		selector.Select(selector.Columns(columns...)...)
 	}
-	if oq.ctx.Unique != nil && *oq.ctx.Unique {
+	if _q.ctx.Unique != nil && *_q.ctx.Unique {
 		selector.Distinct()
 	}
-	for _, p := range oq.predicates {
+	for _, p := range _q.predicates {
 		p(selector)
 	}
-	for _, p := range oq.order {
+	for _, p := range _q.order {
 		p(selector)
 	}
-	if offset := oq.ctx.Offset; offset != nil {
+	if offset := _q.ctx.Offset; offset != nil {
 		// limit is mandatory for offset clause. We start
 		// with default value, and override it below if needed.
 		selector.Offset(*offset).Limit(math.MaxInt32)
 	}
-	if limit := oq.ctx.Limit; limit != nil {
+	if limit := _q.ctx.Limit; limit != nil {
 		selector.Limit(*limit)
 	}
 	return selector
@@ -456,41 +456,41 @@ type OrganizationGroupBy struct {
 }
 
 // Aggregate adds the given aggregation functions to the group-by query.
-func (ogb *OrganizationGroupBy) Aggregate(fns ...AggregateFunc) *OrganizationGroupBy {
-	ogb.fns = append(ogb.fns, fns...)
-	return ogb
+func (_g *OrganizationGroupBy) Aggregate(fns ...AggregateFunc) *OrganizationGroupBy {
+	_g.fns = append(_g.fns, fns...)
+	return _g
 }
 
 // Scan applies the selector query and scans the result into the given value.
-func (ogb *OrganizationGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, ogb.build.ctx, ent.OpQueryGroupBy)
-	if err := ogb.build.prepareQuery(ctx); err != nil {
+func (_g *OrganizationGroupBy) Scan(ctx context.Context, v any) error {
+	ctx = setContextOp(ctx, _g.build.ctx, ent.OpQueryGroupBy)
+	if err := _g.build.prepareQuery(ctx); err != nil {
 		return err
 	}
-	return scanWithInterceptors[*OrganizationQuery, *OrganizationGroupBy](ctx, ogb.build, ogb, ogb.build.inters, v)
+	return scanWithInterceptors[*OrganizationQuery, *OrganizationGroupBy](ctx, _g.build, _g, _g.build.inters, v)
 }
 
-func (ogb *OrganizationGroupBy) sqlScan(ctx context.Context, root *OrganizationQuery, v any) error {
+func (_g *OrganizationGroupBy) sqlScan(ctx context.Context, root *OrganizationQuery, v any) error {
 	selector := root.sqlQuery(ctx).Select()
-	aggregation := make([]string, 0, len(ogb.fns))
-	for _, fn := range ogb.fns {
+	aggregation := make([]string, 0, len(_g.fns))
+	for _, fn := range _g.fns {
 		aggregation = append(aggregation, fn(selector))
 	}
 	if len(selector.SelectedColumns()) == 0 {
-		columns := make([]string, 0, len(*ogb.flds)+len(ogb.fns))
-		for _, f := range *ogb.flds {
+		columns := make([]string, 0, len(*_g.flds)+len(_g.fns))
+		for _, f := range *_g.flds {
 			columns = append(columns, selector.C(f))
 		}
 		columns = append(columns, aggregation...)
 		selector.Select(columns...)
 	}
-	selector.GroupBy(selector.Columns(*ogb.flds...)...)
+	selector.GroupBy(selector.Columns(*_g.flds...)...)
 	if err := selector.Err(); err != nil {
 		return err
 	}
 	rows := &sql.Rows{}
 	query, args := selector.Query()
-	if err := ogb.build.driver.Query(ctx, query, args, rows); err != nil {
+	if err := _g.build.driver.Query(ctx, query, args, rows); err != nil {
 		return err
 	}
 	defer rows.Close()
@@ -504,27 +504,27 @@ type OrganizationSelect struct {
 }
 
 // Aggregate adds the given aggregation functions to the selector query.
-func (os *OrganizationSelect) Aggregate(fns ...AggregateFunc) *OrganizationSelect {
-	os.fns = append(os.fns, fns...)
-	return os
+func (_s *OrganizationSelect) Aggregate(fns ...AggregateFunc) *OrganizationSelect {
+	_s.fns = append(_s.fns, fns...)
+	return _s
 }
 
 // Scan applies the selector query and scans the result into the given value.
-func (os *OrganizationSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, os.ctx, ent.OpQuerySelect)
-	if err := os.prepareQuery(ctx); err != nil {
+func (_s *OrganizationSelect) Scan(ctx context.Context, v any) error {
+	ctx = setContextOp(ctx, _s.ctx, ent.OpQuerySelect)
+	if err := _s.prepareQuery(ctx); err != nil {
 		return err
 	}
-	return scanWithInterceptors[*OrganizationQuery, *OrganizationSelect](ctx, os.OrganizationQuery, os, os.inters, v)
+	return scanWithInterceptors[*OrganizationQuery, *OrganizationSelect](ctx, _s.OrganizationQuery, _s, _s.inters, v)
 }
 
-func (os *OrganizationSelect) sqlScan(ctx context.Context, root *OrganizationQuery, v any) error {
+func (_s *OrganizationSelect) sqlScan(ctx context.Context, root *OrganizationQuery, v any) error {
 	selector := root.sqlQuery(ctx)
-	aggregation := make([]string, 0, len(os.fns))
-	for _, fn := range os.fns {
+	aggregation := make([]string, 0, len(_s.fns))
+	for _, fn := range _s.fns {
 		aggregation = append(aggregation, fn(selector))
 	}
-	switch n := len(*os.selector.flds); {
+	switch n := len(*_s.selector.flds); {
 	case n == 0 && len(aggregation) > 0:
 		selector.Select(aggregation...)
 	case n != 0 && len(aggregation) > 0:
@@ -532,7 +532,7 @@ func (os *OrganizationSelect) sqlScan(ctx context.Context, root *OrganizationQue
 	}
 	rows := &sql.Rows{}
 	query, args := selector.Query()
-	if err := os.driver.Query(ctx, query, args, rows); err != nil {
+	if err := _s.driver.Query(ctx, query, args, rows); err != nil {
 		return err
 	}
 	defer rows.Close()

--- a/vanilla/_example/ent/organization_update.go
+++ b/vanilla/_example/ent/organization_update.go
@@ -23,93 +23,93 @@ type OrganizationUpdate struct {
 }
 
 // Where appends a list predicates to the OrganizationUpdate builder.
-func (ou *OrganizationUpdate) Where(ps ...predicate.Organization) *OrganizationUpdate {
-	ou.mutation.Where(ps...)
-	return ou
+func (_u *OrganizationUpdate) Where(ps ...predicate.Organization) *OrganizationUpdate {
+	_u.mutation.Where(ps...)
+	return _u
 }
 
 // SetUpdatedAt sets the "updated_at" field.
-func (ou *OrganizationUpdate) SetUpdatedAt(t time.Time) *OrganizationUpdate {
-	ou.mutation.SetUpdatedAt(t)
-	return ou
+func (_u *OrganizationUpdate) SetUpdatedAt(v time.Time) *OrganizationUpdate {
+	_u.mutation.SetUpdatedAt(v)
+	return _u
 }
 
 // ClearUpdatedAt clears the value of the "updated_at" field.
-func (ou *OrganizationUpdate) ClearUpdatedAt() *OrganizationUpdate {
-	ou.mutation.ClearUpdatedAt()
-	return ou
+func (_u *OrganizationUpdate) ClearUpdatedAt() *OrganizationUpdate {
+	_u.mutation.ClearUpdatedAt()
+	return _u
 }
 
 // SetUpdatedBy sets the "updated_by" field.
-func (ou *OrganizationUpdate) SetUpdatedBy(s string) *OrganizationUpdate {
-	ou.mutation.SetUpdatedBy(s)
-	return ou
+func (_u *OrganizationUpdate) SetUpdatedBy(v string) *OrganizationUpdate {
+	_u.mutation.SetUpdatedBy(v)
+	return _u
 }
 
 // SetNillableUpdatedBy sets the "updated_by" field if the given value is not nil.
-func (ou *OrganizationUpdate) SetNillableUpdatedBy(s *string) *OrganizationUpdate {
-	if s != nil {
-		ou.SetUpdatedBy(*s)
+func (_u *OrganizationUpdate) SetNillableUpdatedBy(v *string) *OrganizationUpdate {
+	if v != nil {
+		_u.SetUpdatedBy(*v)
 	}
-	return ou
+	return _u
 }
 
 // ClearUpdatedBy clears the value of the "updated_by" field.
-func (ou *OrganizationUpdate) ClearUpdatedBy() *OrganizationUpdate {
-	ou.mutation.ClearUpdatedBy()
-	return ou
+func (_u *OrganizationUpdate) ClearUpdatedBy() *OrganizationUpdate {
+	_u.mutation.ClearUpdatedBy()
+	return _u
 }
 
 // SetName sets the "name" field.
-func (ou *OrganizationUpdate) SetName(s string) *OrganizationUpdate {
-	ou.mutation.SetName(s)
-	return ou
+func (_u *OrganizationUpdate) SetName(v string) *OrganizationUpdate {
+	_u.mutation.SetName(v)
+	return _u
 }
 
 // SetNillableName sets the "name" field if the given value is not nil.
-func (ou *OrganizationUpdate) SetNillableName(s *string) *OrganizationUpdate {
-	if s != nil {
-		ou.SetName(*s)
+func (_u *OrganizationUpdate) SetNillableName(v *string) *OrganizationUpdate {
+	if v != nil {
+		_u.SetName(*v)
 	}
-	return ou
+	return _u
 }
 
 // SetDescription sets the "description" field.
-func (ou *OrganizationUpdate) SetDescription(s string) *OrganizationUpdate {
-	ou.mutation.SetDescription(s)
-	return ou
+func (_u *OrganizationUpdate) SetDescription(v string) *OrganizationUpdate {
+	_u.mutation.SetDescription(v)
+	return _u
 }
 
 // SetNillableDescription sets the "description" field if the given value is not nil.
-func (ou *OrganizationUpdate) SetNillableDescription(s *string) *OrganizationUpdate {
-	if s != nil {
-		ou.SetDescription(*s)
+func (_u *OrganizationUpdate) SetNillableDescription(v *string) *OrganizationUpdate {
+	if v != nil {
+		_u.SetDescription(*v)
 	}
-	return ou
+	return _u
 }
 
 // ClearDescription clears the value of the "description" field.
-func (ou *OrganizationUpdate) ClearDescription() *OrganizationUpdate {
-	ou.mutation.ClearDescription()
-	return ou
+func (_u *OrganizationUpdate) ClearDescription() *OrganizationUpdate {
+	_u.mutation.ClearDescription()
+	return _u
 }
 
 // Mutation returns the OrganizationMutation object of the builder.
-func (ou *OrganizationUpdate) Mutation() *OrganizationMutation {
-	return ou.mutation
+func (_u *OrganizationUpdate) Mutation() *OrganizationMutation {
+	return _u.mutation
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
-func (ou *OrganizationUpdate) Save(ctx context.Context) (int, error) {
-	if err := ou.defaults(); err != nil {
+func (_u *OrganizationUpdate) Save(ctx context.Context) (int, error) {
+	if err := _u.defaults(); err != nil {
 		return 0, err
 	}
-	return withHooks(ctx, ou.sqlSave, ou.mutation, ou.hooks)
+	return withHooks(ctx, _u.sqlSave, _u.mutation, _u.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
-func (ou *OrganizationUpdate) SaveX(ctx context.Context) int {
-	affected, err := ou.Save(ctx)
+func (_u *OrganizationUpdate) SaveX(ctx context.Context) int {
+	affected, err := _u.Save(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -117,33 +117,33 @@ func (ou *OrganizationUpdate) SaveX(ctx context.Context) int {
 }
 
 // Exec executes the query.
-func (ou *OrganizationUpdate) Exec(ctx context.Context) error {
-	_, err := ou.Save(ctx)
+func (_u *OrganizationUpdate) Exec(ctx context.Context) error {
+	_, err := _u.Save(ctx)
 	return err
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (ou *OrganizationUpdate) ExecX(ctx context.Context) {
-	if err := ou.Exec(ctx); err != nil {
+func (_u *OrganizationUpdate) ExecX(ctx context.Context) {
+	if err := _u.Exec(ctx); err != nil {
 		panic(err)
 	}
 }
 
 // defaults sets the default values of the builder before save.
-func (ou *OrganizationUpdate) defaults() error {
-	if _, ok := ou.mutation.UpdatedAt(); !ok && !ou.mutation.UpdatedAtCleared() {
+func (_u *OrganizationUpdate) defaults() error {
+	if _, ok := _u.mutation.UpdatedAt(); !ok && !_u.mutation.UpdatedAtCleared() {
 		if organization.UpdateDefaultUpdatedAt == nil {
 			return fmt.Errorf("ent: uninitialized organization.UpdateDefaultUpdatedAt (forgotten import ent/runtime?)")
 		}
 		v := organization.UpdateDefaultUpdatedAt()
-		ou.mutation.SetUpdatedAt(v)
+		_u.mutation.SetUpdatedAt(v)
 	}
 	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
-func (ou *OrganizationUpdate) check() error {
-	if v, ok := ou.mutation.Name(); ok {
+func (_u *OrganizationUpdate) check() error {
+	if v, ok := _u.mutation.Name(); ok {
 		if err := organization.NameValidator(v); err != nil {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Organization.name": %w`, err)}
 		}
@@ -151,46 +151,46 @@ func (ou *OrganizationUpdate) check() error {
 	return nil
 }
 
-func (ou *OrganizationUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	if err := ou.check(); err != nil {
-		return n, err
+func (_u *OrganizationUpdate) sqlSave(ctx context.Context) (_node int, err error) {
+	if err := _u.check(); err != nil {
+		return _node, err
 	}
 	_spec := sqlgraph.NewUpdateSpec(organization.Table, organization.Columns, sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString))
-	if ps := ou.mutation.predicates; len(ps) > 0 {
+	if ps := _u.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	if ou.mutation.CreatedAtCleared() {
+	if _u.mutation.CreatedAtCleared() {
 		_spec.ClearField(organization.FieldCreatedAt, field.TypeTime)
 	}
-	if value, ok := ou.mutation.UpdatedAt(); ok {
+	if value, ok := _u.mutation.UpdatedAt(); ok {
 		_spec.SetField(organization.FieldUpdatedAt, field.TypeTime, value)
 	}
-	if ou.mutation.UpdatedAtCleared() {
+	if _u.mutation.UpdatedAtCleared() {
 		_spec.ClearField(organization.FieldUpdatedAt, field.TypeTime)
 	}
-	if ou.mutation.CreatedByCleared() {
+	if _u.mutation.CreatedByCleared() {
 		_spec.ClearField(organization.FieldCreatedBy, field.TypeString)
 	}
-	if value, ok := ou.mutation.UpdatedBy(); ok {
+	if value, ok := _u.mutation.UpdatedBy(); ok {
 		_spec.SetField(organization.FieldUpdatedBy, field.TypeString, value)
 	}
-	if ou.mutation.UpdatedByCleared() {
+	if _u.mutation.UpdatedByCleared() {
 		_spec.ClearField(organization.FieldUpdatedBy, field.TypeString)
 	}
-	if value, ok := ou.mutation.Name(); ok {
+	if value, ok := _u.mutation.Name(); ok {
 		_spec.SetField(organization.FieldName, field.TypeString, value)
 	}
-	if value, ok := ou.mutation.Description(); ok {
+	if value, ok := _u.mutation.Description(); ok {
 		_spec.SetField(organization.FieldDescription, field.TypeString, value)
 	}
-	if ou.mutation.DescriptionCleared() {
+	if _u.mutation.DescriptionCleared() {
 		_spec.ClearField(organization.FieldDescription, field.TypeString)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, ou.driver, _spec); err != nil {
+	if _node, err = sqlgraph.UpdateNodes(ctx, _u.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{organization.Label}
 		} else if sqlgraph.IsConstraintError(err) {
@@ -198,8 +198,8 @@ func (ou *OrganizationUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		return 0, err
 	}
-	ou.mutation.done = true
-	return n, nil
+	_u.mutation.done = true
+	return _node, nil
 }
 
 // OrganizationUpdateOne is the builder for updating a single Organization entity.
@@ -211,100 +211,100 @@ type OrganizationUpdateOne struct {
 }
 
 // SetUpdatedAt sets the "updated_at" field.
-func (ouo *OrganizationUpdateOne) SetUpdatedAt(t time.Time) *OrganizationUpdateOne {
-	ouo.mutation.SetUpdatedAt(t)
-	return ouo
+func (_u *OrganizationUpdateOne) SetUpdatedAt(v time.Time) *OrganizationUpdateOne {
+	_u.mutation.SetUpdatedAt(v)
+	return _u
 }
 
 // ClearUpdatedAt clears the value of the "updated_at" field.
-func (ouo *OrganizationUpdateOne) ClearUpdatedAt() *OrganizationUpdateOne {
-	ouo.mutation.ClearUpdatedAt()
-	return ouo
+func (_u *OrganizationUpdateOne) ClearUpdatedAt() *OrganizationUpdateOne {
+	_u.mutation.ClearUpdatedAt()
+	return _u
 }
 
 // SetUpdatedBy sets the "updated_by" field.
-func (ouo *OrganizationUpdateOne) SetUpdatedBy(s string) *OrganizationUpdateOne {
-	ouo.mutation.SetUpdatedBy(s)
-	return ouo
+func (_u *OrganizationUpdateOne) SetUpdatedBy(v string) *OrganizationUpdateOne {
+	_u.mutation.SetUpdatedBy(v)
+	return _u
 }
 
 // SetNillableUpdatedBy sets the "updated_by" field if the given value is not nil.
-func (ouo *OrganizationUpdateOne) SetNillableUpdatedBy(s *string) *OrganizationUpdateOne {
-	if s != nil {
-		ouo.SetUpdatedBy(*s)
+func (_u *OrganizationUpdateOne) SetNillableUpdatedBy(v *string) *OrganizationUpdateOne {
+	if v != nil {
+		_u.SetUpdatedBy(*v)
 	}
-	return ouo
+	return _u
 }
 
 // ClearUpdatedBy clears the value of the "updated_by" field.
-func (ouo *OrganizationUpdateOne) ClearUpdatedBy() *OrganizationUpdateOne {
-	ouo.mutation.ClearUpdatedBy()
-	return ouo
+func (_u *OrganizationUpdateOne) ClearUpdatedBy() *OrganizationUpdateOne {
+	_u.mutation.ClearUpdatedBy()
+	return _u
 }
 
 // SetName sets the "name" field.
-func (ouo *OrganizationUpdateOne) SetName(s string) *OrganizationUpdateOne {
-	ouo.mutation.SetName(s)
-	return ouo
+func (_u *OrganizationUpdateOne) SetName(v string) *OrganizationUpdateOne {
+	_u.mutation.SetName(v)
+	return _u
 }
 
 // SetNillableName sets the "name" field if the given value is not nil.
-func (ouo *OrganizationUpdateOne) SetNillableName(s *string) *OrganizationUpdateOne {
-	if s != nil {
-		ouo.SetName(*s)
+func (_u *OrganizationUpdateOne) SetNillableName(v *string) *OrganizationUpdateOne {
+	if v != nil {
+		_u.SetName(*v)
 	}
-	return ouo
+	return _u
 }
 
 // SetDescription sets the "description" field.
-func (ouo *OrganizationUpdateOne) SetDescription(s string) *OrganizationUpdateOne {
-	ouo.mutation.SetDescription(s)
-	return ouo
+func (_u *OrganizationUpdateOne) SetDescription(v string) *OrganizationUpdateOne {
+	_u.mutation.SetDescription(v)
+	return _u
 }
 
 // SetNillableDescription sets the "description" field if the given value is not nil.
-func (ouo *OrganizationUpdateOne) SetNillableDescription(s *string) *OrganizationUpdateOne {
-	if s != nil {
-		ouo.SetDescription(*s)
+func (_u *OrganizationUpdateOne) SetNillableDescription(v *string) *OrganizationUpdateOne {
+	if v != nil {
+		_u.SetDescription(*v)
 	}
-	return ouo
+	return _u
 }
 
 // ClearDescription clears the value of the "description" field.
-func (ouo *OrganizationUpdateOne) ClearDescription() *OrganizationUpdateOne {
-	ouo.mutation.ClearDescription()
-	return ouo
+func (_u *OrganizationUpdateOne) ClearDescription() *OrganizationUpdateOne {
+	_u.mutation.ClearDescription()
+	return _u
 }
 
 // Mutation returns the OrganizationMutation object of the builder.
-func (ouo *OrganizationUpdateOne) Mutation() *OrganizationMutation {
-	return ouo.mutation
+func (_u *OrganizationUpdateOne) Mutation() *OrganizationMutation {
+	return _u.mutation
 }
 
 // Where appends a list predicates to the OrganizationUpdate builder.
-func (ouo *OrganizationUpdateOne) Where(ps ...predicate.Organization) *OrganizationUpdateOne {
-	ouo.mutation.Where(ps...)
-	return ouo
+func (_u *OrganizationUpdateOne) Where(ps ...predicate.Organization) *OrganizationUpdateOne {
+	_u.mutation.Where(ps...)
+	return _u
 }
 
 // Select allows selecting one or more fields (columns) of the returned entity.
 // The default is selecting all fields defined in the entity schema.
-func (ouo *OrganizationUpdateOne) Select(field string, fields ...string) *OrganizationUpdateOne {
-	ouo.fields = append([]string{field}, fields...)
-	return ouo
+func (_u *OrganizationUpdateOne) Select(field string, fields ...string) *OrganizationUpdateOne {
+	_u.fields = append([]string{field}, fields...)
+	return _u
 }
 
 // Save executes the query and returns the updated Organization entity.
-func (ouo *OrganizationUpdateOne) Save(ctx context.Context) (*Organization, error) {
-	if err := ouo.defaults(); err != nil {
+func (_u *OrganizationUpdateOne) Save(ctx context.Context) (*Organization, error) {
+	if err := _u.defaults(); err != nil {
 		return nil, err
 	}
-	return withHooks(ctx, ouo.sqlSave, ouo.mutation, ouo.hooks)
+	return withHooks(ctx, _u.sqlSave, _u.mutation, _u.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
-func (ouo *OrganizationUpdateOne) SaveX(ctx context.Context) *Organization {
-	node, err := ouo.Save(ctx)
+func (_u *OrganizationUpdateOne) SaveX(ctx context.Context) *Organization {
+	node, err := _u.Save(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -312,33 +312,33 @@ func (ouo *OrganizationUpdateOne) SaveX(ctx context.Context) *Organization {
 }
 
 // Exec executes the query on the entity.
-func (ouo *OrganizationUpdateOne) Exec(ctx context.Context) error {
-	_, err := ouo.Save(ctx)
+func (_u *OrganizationUpdateOne) Exec(ctx context.Context) error {
+	_, err := _u.Save(ctx)
 	return err
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (ouo *OrganizationUpdateOne) ExecX(ctx context.Context) {
-	if err := ouo.Exec(ctx); err != nil {
+func (_u *OrganizationUpdateOne) ExecX(ctx context.Context) {
+	if err := _u.Exec(ctx); err != nil {
 		panic(err)
 	}
 }
 
 // defaults sets the default values of the builder before save.
-func (ouo *OrganizationUpdateOne) defaults() error {
-	if _, ok := ouo.mutation.UpdatedAt(); !ok && !ouo.mutation.UpdatedAtCleared() {
+func (_u *OrganizationUpdateOne) defaults() error {
+	if _, ok := _u.mutation.UpdatedAt(); !ok && !_u.mutation.UpdatedAtCleared() {
 		if organization.UpdateDefaultUpdatedAt == nil {
 			return fmt.Errorf("ent: uninitialized organization.UpdateDefaultUpdatedAt (forgotten import ent/runtime?)")
 		}
 		v := organization.UpdateDefaultUpdatedAt()
-		ouo.mutation.SetUpdatedAt(v)
+		_u.mutation.SetUpdatedAt(v)
 	}
 	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
-func (ouo *OrganizationUpdateOne) check() error {
-	if v, ok := ouo.mutation.Name(); ok {
+func (_u *OrganizationUpdateOne) check() error {
+	if v, ok := _u.mutation.Name(); ok {
 		if err := organization.NameValidator(v); err != nil {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Organization.name": %w`, err)}
 		}
@@ -346,17 +346,17 @@ func (ouo *OrganizationUpdateOne) check() error {
 	return nil
 }
 
-func (ouo *OrganizationUpdateOne) sqlSave(ctx context.Context) (_node *Organization, err error) {
-	if err := ouo.check(); err != nil {
+func (_u *OrganizationUpdateOne) sqlSave(ctx context.Context) (_node *Organization, err error) {
+	if err := _u.check(); err != nil {
 		return _node, err
 	}
 	_spec := sqlgraph.NewUpdateSpec(organization.Table, organization.Columns, sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString))
-	id, ok := ouo.mutation.ID()
+	id, ok := _u.mutation.ID()
 	if !ok {
 		return nil, &ValidationError{Name: "id", err: errors.New(`ent: missing "Organization.id" for update`)}
 	}
 	_spec.Node.ID.Value = id
-	if fields := ouo.fields; len(fields) > 0 {
+	if fields := _u.fields; len(fields) > 0 {
 		_spec.Node.Columns = make([]string, 0, len(fields))
 		_spec.Node.Columns = append(_spec.Node.Columns, organization.FieldID)
 		for _, f := range fields {
@@ -368,44 +368,44 @@ func (ouo *OrganizationUpdateOne) sqlSave(ctx context.Context) (_node *Organizat
 			}
 		}
 	}
-	if ps := ouo.mutation.predicates; len(ps) > 0 {
+	if ps := _u.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	if ouo.mutation.CreatedAtCleared() {
+	if _u.mutation.CreatedAtCleared() {
 		_spec.ClearField(organization.FieldCreatedAt, field.TypeTime)
 	}
-	if value, ok := ouo.mutation.UpdatedAt(); ok {
+	if value, ok := _u.mutation.UpdatedAt(); ok {
 		_spec.SetField(organization.FieldUpdatedAt, field.TypeTime, value)
 	}
-	if ouo.mutation.UpdatedAtCleared() {
+	if _u.mutation.UpdatedAtCleared() {
 		_spec.ClearField(organization.FieldUpdatedAt, field.TypeTime)
 	}
-	if ouo.mutation.CreatedByCleared() {
+	if _u.mutation.CreatedByCleared() {
 		_spec.ClearField(organization.FieldCreatedBy, field.TypeString)
 	}
-	if value, ok := ouo.mutation.UpdatedBy(); ok {
+	if value, ok := _u.mutation.UpdatedBy(); ok {
 		_spec.SetField(organization.FieldUpdatedBy, field.TypeString, value)
 	}
-	if ouo.mutation.UpdatedByCleared() {
+	if _u.mutation.UpdatedByCleared() {
 		_spec.ClearField(organization.FieldUpdatedBy, field.TypeString)
 	}
-	if value, ok := ouo.mutation.Name(); ok {
+	if value, ok := _u.mutation.Name(); ok {
 		_spec.SetField(organization.FieldName, field.TypeString, value)
 	}
-	if value, ok := ouo.mutation.Description(); ok {
+	if value, ok := _u.mutation.Description(); ok {
 		_spec.SetField(organization.FieldDescription, field.TypeString, value)
 	}
-	if ouo.mutation.DescriptionCleared() {
+	if _u.mutation.DescriptionCleared() {
 		_spec.ClearField(organization.FieldDescription, field.TypeString)
 	}
-	_node = &Organization{config: ouo.config}
+	_node = &Organization{config: _u.config}
 	_spec.Assign = _node.assignValues
 	_spec.ScanValues = _node.scanValues
-	if err = sqlgraph.UpdateNode(ctx, ouo.driver, _spec); err != nil {
+	if err = sqlgraph.UpdateNode(ctx, _u.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{organization.Label}
 		} else if sqlgraph.IsConstraintError(err) {
@@ -413,6 +413,6 @@ func (ouo *OrganizationUpdateOne) sqlSave(ctx context.Context) (_node *Organizat
 		}
 		return nil, err
 	}
-	ouo.mutation.done = true
+	_u.mutation.done = true
 	return _node, nil
 }

--- a/vanilla/_example/ent/orgmembership.go
+++ b/vanilla/_example/ent/orgmembership.go
@@ -68,7 +68,7 @@ func (*OrgMembership) scanValues(columns []string) ([]any, error) {
 
 // assignValues assigns the values that were returned from sql.Rows (after scanning)
 // to the OrgMembership fields.
-func (om *OrgMembership) assignValues(columns []string, values []any) error {
+func (_m *OrgMembership) assignValues(columns []string, values []any) error {
 	if m, n := len(values), len(columns); m < n {
 		return fmt.Errorf("mismatch number of scan values: %d != %d", m, n)
 	}
@@ -78,28 +78,28 @@ func (om *OrgMembership) assignValues(columns []string, values []any) error {
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field id", values[i])
 			} else if value.Valid {
-				om.ID = value.String
+				_m.ID = value.String
 			}
 		case orgmembership.FieldRole:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field role", values[i])
 			} else if value.Valid {
-				om.Role = enums.Role(value.String)
+				_m.Role = enums.Role(value.String)
 			}
 		case orgmembership.FieldOrganizationID:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field organization_id", values[i])
 			} else if value.Valid {
-				om.OrganizationID = value.String
+				_m.OrganizationID = value.String
 			}
 		case orgmembership.FieldUserID:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field user_id", values[i])
 			} else if value.Valid {
-				om.UserID = value.String
+				_m.UserID = value.String
 			}
 		default:
-			om.selectValues.Set(columns[i], values[i])
+			_m.selectValues.Set(columns[i], values[i])
 		}
 	}
 	return nil
@@ -107,46 +107,46 @@ func (om *OrgMembership) assignValues(columns []string, values []any) error {
 
 // Value returns the ent.Value that was dynamically selected and assigned to the OrgMembership.
 // This includes values selected through modifiers, order, etc.
-func (om *OrgMembership) Value(name string) (ent.Value, error) {
-	return om.selectValues.Get(name)
+func (_m *OrgMembership) Value(name string) (ent.Value, error) {
+	return _m.selectValues.Get(name)
 }
 
 // QueryOrganization queries the "organization" edge of the OrgMembership entity.
-func (om *OrgMembership) QueryOrganization() *OrganizationQuery {
-	return NewOrgMembershipClient(om.config).QueryOrganization(om)
+func (_m *OrgMembership) QueryOrganization() *OrganizationQuery {
+	return NewOrgMembershipClient(_m.config).QueryOrganization(_m)
 }
 
 // Update returns a builder for updating this OrgMembership.
 // Note that you need to call OrgMembership.Unwrap() before calling this method if this OrgMembership
 // was returned from a transaction, and the transaction was committed or rolled back.
-func (om *OrgMembership) Update() *OrgMembershipUpdateOne {
-	return NewOrgMembershipClient(om.config).UpdateOne(om)
+func (_m *OrgMembership) Update() *OrgMembershipUpdateOne {
+	return NewOrgMembershipClient(_m.config).UpdateOne(_m)
 }
 
 // Unwrap unwraps the OrgMembership entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
-func (om *OrgMembership) Unwrap() *OrgMembership {
-	_tx, ok := om.config.driver.(*txDriver)
+func (_m *OrgMembership) Unwrap() *OrgMembership {
+	_tx, ok := _m.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: OrgMembership is not a transactional entity")
 	}
-	om.config.driver = _tx.drv
-	return om
+	_m.config.driver = _tx.drv
+	return _m
 }
 
 // String implements the fmt.Stringer.
-func (om *OrgMembership) String() string {
+func (_m *OrgMembership) String() string {
 	var builder strings.Builder
 	builder.WriteString("OrgMembership(")
-	builder.WriteString(fmt.Sprintf("id=%v, ", om.ID))
+	builder.WriteString(fmt.Sprintf("id=%v, ", _m.ID))
 	builder.WriteString("role=")
-	builder.WriteString(fmt.Sprintf("%v", om.Role))
+	builder.WriteString(fmt.Sprintf("%v", _m.Role))
 	builder.WriteString(", ")
 	builder.WriteString("organization_id=")
-	builder.WriteString(om.OrganizationID)
+	builder.WriteString(_m.OrganizationID)
 	builder.WriteString(", ")
 	builder.WriteString("user_id=")
-	builder.WriteString(om.UserID)
+	builder.WriteString(_m.UserID)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/vanilla/_example/ent/orgmembership_create.go
+++ b/vanilla/_example/ent/orgmembership_create.go
@@ -22,56 +22,56 @@ type OrgMembershipCreate struct {
 }
 
 // SetRole sets the "role" field.
-func (omc *OrgMembershipCreate) SetRole(e enums.Role) *OrgMembershipCreate {
-	omc.mutation.SetRole(e)
-	return omc
+func (_c *OrgMembershipCreate) SetRole(v enums.Role) *OrgMembershipCreate {
+	_c.mutation.SetRole(v)
+	return _c
 }
 
 // SetNillableRole sets the "role" field if the given value is not nil.
-func (omc *OrgMembershipCreate) SetNillableRole(e *enums.Role) *OrgMembershipCreate {
-	if e != nil {
-		omc.SetRole(*e)
+func (_c *OrgMembershipCreate) SetNillableRole(v *enums.Role) *OrgMembershipCreate {
+	if v != nil {
+		_c.SetRole(*v)
 	}
-	return omc
+	return _c
 }
 
 // SetOrganizationID sets the "organization_id" field.
-func (omc *OrgMembershipCreate) SetOrganizationID(s string) *OrgMembershipCreate {
-	omc.mutation.SetOrganizationID(s)
-	return omc
+func (_c *OrgMembershipCreate) SetOrganizationID(v string) *OrgMembershipCreate {
+	_c.mutation.SetOrganizationID(v)
+	return _c
 }
 
 // SetUserID sets the "user_id" field.
-func (omc *OrgMembershipCreate) SetUserID(s string) *OrgMembershipCreate {
-	omc.mutation.SetUserID(s)
-	return omc
+func (_c *OrgMembershipCreate) SetUserID(v string) *OrgMembershipCreate {
+	_c.mutation.SetUserID(v)
+	return _c
 }
 
 // SetID sets the "id" field.
-func (omc *OrgMembershipCreate) SetID(s string) *OrgMembershipCreate {
-	omc.mutation.SetID(s)
-	return omc
+func (_c *OrgMembershipCreate) SetID(v string) *OrgMembershipCreate {
+	_c.mutation.SetID(v)
+	return _c
 }
 
 // SetOrganization sets the "organization" edge to the Organization entity.
-func (omc *OrgMembershipCreate) SetOrganization(o *Organization) *OrgMembershipCreate {
-	return omc.SetOrganizationID(o.ID)
+func (_c *OrgMembershipCreate) SetOrganization(v *Organization) *OrgMembershipCreate {
+	return _c.SetOrganizationID(v.ID)
 }
 
 // Mutation returns the OrgMembershipMutation object of the builder.
-func (omc *OrgMembershipCreate) Mutation() *OrgMembershipMutation {
-	return omc.mutation
+func (_c *OrgMembershipCreate) Mutation() *OrgMembershipMutation {
+	return _c.mutation
 }
 
 // Save creates the OrgMembership in the database.
-func (omc *OrgMembershipCreate) Save(ctx context.Context) (*OrgMembership, error) {
-	omc.defaults()
-	return withHooks(ctx, omc.sqlSave, omc.mutation, omc.hooks)
+func (_c *OrgMembershipCreate) Save(ctx context.Context) (*OrgMembership, error) {
+	_c.defaults()
+	return withHooks(ctx, _c.sqlSave, _c.mutation, _c.hooks)
 }
 
 // SaveX calls Save and panics if Save returns an error.
-func (omc *OrgMembershipCreate) SaveX(ctx context.Context) *OrgMembership {
-	v, err := omc.Save(ctx)
+func (_c *OrgMembershipCreate) SaveX(ctx context.Context) *OrgMembership {
+	v, err := _c.Save(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -79,54 +79,54 @@ func (omc *OrgMembershipCreate) SaveX(ctx context.Context) *OrgMembership {
 }
 
 // Exec executes the query.
-func (omc *OrgMembershipCreate) Exec(ctx context.Context) error {
-	_, err := omc.Save(ctx)
+func (_c *OrgMembershipCreate) Exec(ctx context.Context) error {
+	_, err := _c.Save(ctx)
 	return err
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (omc *OrgMembershipCreate) ExecX(ctx context.Context) {
-	if err := omc.Exec(ctx); err != nil {
+func (_c *OrgMembershipCreate) ExecX(ctx context.Context) {
+	if err := _c.Exec(ctx); err != nil {
 		panic(err)
 	}
 }
 
 // defaults sets the default values of the builder before save.
-func (omc *OrgMembershipCreate) defaults() {
-	if _, ok := omc.mutation.Role(); !ok {
+func (_c *OrgMembershipCreate) defaults() {
+	if _, ok := _c.mutation.Role(); !ok {
 		v := orgmembership.DefaultRole
-		omc.mutation.SetRole(v)
+		_c.mutation.SetRole(v)
 	}
 }
 
 // check runs all checks and user-defined validators on the builder.
-func (omc *OrgMembershipCreate) check() error {
-	if _, ok := omc.mutation.Role(); !ok {
+func (_c *OrgMembershipCreate) check() error {
+	if _, ok := _c.mutation.Role(); !ok {
 		return &ValidationError{Name: "role", err: errors.New(`ent: missing required field "OrgMembership.role"`)}
 	}
-	if v, ok := omc.mutation.Role(); ok {
+	if v, ok := _c.mutation.Role(); ok {
 		if err := orgmembership.RoleValidator(v); err != nil {
 			return &ValidationError{Name: "role", err: fmt.Errorf(`ent: validator failed for field "OrgMembership.role": %w`, err)}
 		}
 	}
-	if _, ok := omc.mutation.OrganizationID(); !ok {
+	if _, ok := _c.mutation.OrganizationID(); !ok {
 		return &ValidationError{Name: "organization_id", err: errors.New(`ent: missing required field "OrgMembership.organization_id"`)}
 	}
-	if _, ok := omc.mutation.UserID(); !ok {
+	if _, ok := _c.mutation.UserID(); !ok {
 		return &ValidationError{Name: "user_id", err: errors.New(`ent: missing required field "OrgMembership.user_id"`)}
 	}
-	if len(omc.mutation.OrganizationIDs()) == 0 {
+	if len(_c.mutation.OrganizationIDs()) == 0 {
 		return &ValidationError{Name: "organization", err: errors.New(`ent: missing required edge "OrgMembership.organization"`)}
 	}
 	return nil
 }
 
-func (omc *OrgMembershipCreate) sqlSave(ctx context.Context) (*OrgMembership, error) {
-	if err := omc.check(); err != nil {
+func (_c *OrgMembershipCreate) sqlSave(ctx context.Context) (*OrgMembership, error) {
+	if err := _c.check(); err != nil {
 		return nil, err
 	}
-	_node, _spec := omc.createSpec()
-	if err := sqlgraph.CreateNode(ctx, omc.driver, _spec); err != nil {
+	_node, _spec := _c.createSpec()
+	if err := sqlgraph.CreateNode(ctx, _c.driver, _spec); err != nil {
 		if sqlgraph.IsConstraintError(err) {
 			err = &ConstraintError{msg: err.Error(), wrap: err}
 		}
@@ -139,29 +139,29 @@ func (omc *OrgMembershipCreate) sqlSave(ctx context.Context) (*OrgMembership, er
 			return nil, fmt.Errorf("unexpected OrgMembership.ID type: %T", _spec.ID.Value)
 		}
 	}
-	omc.mutation.id = &_node.ID
-	omc.mutation.done = true
+	_c.mutation.id = &_node.ID
+	_c.mutation.done = true
 	return _node, nil
 }
 
-func (omc *OrgMembershipCreate) createSpec() (*OrgMembership, *sqlgraph.CreateSpec) {
+func (_c *OrgMembershipCreate) createSpec() (*OrgMembership, *sqlgraph.CreateSpec) {
 	var (
-		_node = &OrgMembership{config: omc.config}
+		_node = &OrgMembership{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(orgmembership.Table, sqlgraph.NewFieldSpec(orgmembership.FieldID, field.TypeString))
 	)
-	if id, ok := omc.mutation.ID(); ok {
+	if id, ok := _c.mutation.ID(); ok {
 		_node.ID = id
 		_spec.ID.Value = id
 	}
-	if value, ok := omc.mutation.Role(); ok {
+	if value, ok := _c.mutation.Role(); ok {
 		_spec.SetField(orgmembership.FieldRole, field.TypeEnum, value)
 		_node.Role = value
 	}
-	if value, ok := omc.mutation.UserID(); ok {
+	if value, ok := _c.mutation.UserID(); ok {
 		_spec.SetField(orgmembership.FieldUserID, field.TypeString, value)
 		_node.UserID = value
 	}
-	if nodes := omc.mutation.OrganizationIDs(); len(nodes) > 0 {
+	if nodes := _c.mutation.OrganizationIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
 			Inverse: false,
@@ -189,16 +189,16 @@ type OrgMembershipCreateBulk struct {
 }
 
 // Save creates the OrgMembership entities in the database.
-func (omcb *OrgMembershipCreateBulk) Save(ctx context.Context) ([]*OrgMembership, error) {
-	if omcb.err != nil {
-		return nil, omcb.err
+func (_c *OrgMembershipCreateBulk) Save(ctx context.Context) ([]*OrgMembership, error) {
+	if _c.err != nil {
+		return nil, _c.err
 	}
-	specs := make([]*sqlgraph.CreateSpec, len(omcb.builders))
-	nodes := make([]*OrgMembership, len(omcb.builders))
-	mutators := make([]Mutator, len(omcb.builders))
-	for i := range omcb.builders {
+	specs := make([]*sqlgraph.CreateSpec, len(_c.builders))
+	nodes := make([]*OrgMembership, len(_c.builders))
+	mutators := make([]Mutator, len(_c.builders))
+	for i := range _c.builders {
 		func(i int, root context.Context) {
-			builder := omcb.builders[i]
+			builder := _c.builders[i]
 			builder.defaults()
 			var mut Mutator = MutateFunc(func(ctx context.Context, m Mutation) (Value, error) {
 				mutation, ok := m.(*OrgMembershipMutation)
@@ -212,11 +212,11 @@ func (omcb *OrgMembershipCreateBulk) Save(ctx context.Context) ([]*OrgMembership
 				var err error
 				nodes[i], specs[i] = builder.createSpec()
 				if i < len(mutators)-1 {
-					_, err = mutators[i+1].Mutate(root, omcb.builders[i+1].mutation)
+					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
 					// Invoke the actual operation on the latest mutation in the chain.
-					if err = sqlgraph.BatchCreate(ctx, omcb.driver, spec); err != nil {
+					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
 							err = &ConstraintError{msg: err.Error(), wrap: err}
 						}
@@ -236,7 +236,7 @@ func (omcb *OrgMembershipCreateBulk) Save(ctx context.Context) ([]*OrgMembership
 		}(i, ctx)
 	}
 	if len(mutators) > 0 {
-		if _, err := mutators[0].Mutate(ctx, omcb.builders[0].mutation); err != nil {
+		if _, err := mutators[0].Mutate(ctx, _c.builders[0].mutation); err != nil {
 			return nil, err
 		}
 	}
@@ -244,8 +244,8 @@ func (omcb *OrgMembershipCreateBulk) Save(ctx context.Context) ([]*OrgMembership
 }
 
 // SaveX is like Save, but panics if an error occurs.
-func (omcb *OrgMembershipCreateBulk) SaveX(ctx context.Context) []*OrgMembership {
-	v, err := omcb.Save(ctx)
+func (_c *OrgMembershipCreateBulk) SaveX(ctx context.Context) []*OrgMembership {
+	v, err := _c.Save(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -253,14 +253,14 @@ func (omcb *OrgMembershipCreateBulk) SaveX(ctx context.Context) []*OrgMembership
 }
 
 // Exec executes the query.
-func (omcb *OrgMembershipCreateBulk) Exec(ctx context.Context) error {
-	_, err := omcb.Save(ctx)
+func (_c *OrgMembershipCreateBulk) Exec(ctx context.Context) error {
+	_, err := _c.Save(ctx)
 	return err
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (omcb *OrgMembershipCreateBulk) ExecX(ctx context.Context) {
-	if err := omcb.Exec(ctx); err != nil {
+func (_c *OrgMembershipCreateBulk) ExecX(ctx context.Context) {
+	if err := _c.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/vanilla/_example/ent/orgmembership_delete.go
+++ b/vanilla/_example/ent/orgmembership_delete.go
@@ -20,56 +20,56 @@ type OrgMembershipDelete struct {
 }
 
 // Where appends a list predicates to the OrgMembershipDelete builder.
-func (omd *OrgMembershipDelete) Where(ps ...predicate.OrgMembership) *OrgMembershipDelete {
-	omd.mutation.Where(ps...)
-	return omd
+func (_d *OrgMembershipDelete) Where(ps ...predicate.OrgMembership) *OrgMembershipDelete {
+	_d.mutation.Where(ps...)
+	return _d
 }
 
 // Exec executes the deletion query and returns how many vertices were deleted.
-func (omd *OrgMembershipDelete) Exec(ctx context.Context) (int, error) {
-	return withHooks(ctx, omd.sqlExec, omd.mutation, omd.hooks)
+func (_d *OrgMembershipDelete) Exec(ctx context.Context) (int, error) {
+	return withHooks(ctx, _d.sqlExec, _d.mutation, _d.hooks)
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (omd *OrgMembershipDelete) ExecX(ctx context.Context) int {
-	n, err := omd.Exec(ctx)
+func (_d *OrgMembershipDelete) ExecX(ctx context.Context) int {
+	n, err := _d.Exec(ctx)
 	if err != nil {
 		panic(err)
 	}
 	return n
 }
 
-func (omd *OrgMembershipDelete) sqlExec(ctx context.Context) (int, error) {
+func (_d *OrgMembershipDelete) sqlExec(ctx context.Context) (int, error) {
 	_spec := sqlgraph.NewDeleteSpec(orgmembership.Table, sqlgraph.NewFieldSpec(orgmembership.FieldID, field.TypeString))
-	if ps := omd.mutation.predicates; len(ps) > 0 {
+	if ps := _d.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	affected, err := sqlgraph.DeleteNodes(ctx, omd.driver, _spec)
+	affected, err := sqlgraph.DeleteNodes(ctx, _d.driver, _spec)
 	if err != nil && sqlgraph.IsConstraintError(err) {
 		err = &ConstraintError{msg: err.Error(), wrap: err}
 	}
-	omd.mutation.done = true
+	_d.mutation.done = true
 	return affected, err
 }
 
 // OrgMembershipDeleteOne is the builder for deleting a single OrgMembership entity.
 type OrgMembershipDeleteOne struct {
-	omd *OrgMembershipDelete
+	_d *OrgMembershipDelete
 }
 
 // Where appends a list predicates to the OrgMembershipDelete builder.
-func (omdo *OrgMembershipDeleteOne) Where(ps ...predicate.OrgMembership) *OrgMembershipDeleteOne {
-	omdo.omd.mutation.Where(ps...)
-	return omdo
+func (_d *OrgMembershipDeleteOne) Where(ps ...predicate.OrgMembership) *OrgMembershipDeleteOne {
+	_d._d.mutation.Where(ps...)
+	return _d
 }
 
 // Exec executes the deletion query.
-func (omdo *OrgMembershipDeleteOne) Exec(ctx context.Context) error {
-	n, err := omdo.omd.Exec(ctx)
+func (_d *OrgMembershipDeleteOne) Exec(ctx context.Context) error {
+	n, err := _d._d.Exec(ctx)
 	switch {
 	case err != nil:
 		return err
@@ -81,8 +81,8 @@ func (omdo *OrgMembershipDeleteOne) Exec(ctx context.Context) error {
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (omdo *OrgMembershipDeleteOne) ExecX(ctx context.Context) {
-	if err := omdo.Exec(ctx); err != nil {
+func (_d *OrgMembershipDeleteOne) ExecX(ctx context.Context) {
+	if err := _d.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/vanilla/_example/ent/orgmembership_query.go
+++ b/vanilla/_example/ent/orgmembership_query.go
@@ -32,44 +32,44 @@ type OrgMembershipQuery struct {
 }
 
 // Where adds a new predicate for the OrgMembershipQuery builder.
-func (omq *OrgMembershipQuery) Where(ps ...predicate.OrgMembership) *OrgMembershipQuery {
-	omq.predicates = append(omq.predicates, ps...)
-	return omq
+func (_q *OrgMembershipQuery) Where(ps ...predicate.OrgMembership) *OrgMembershipQuery {
+	_q.predicates = append(_q.predicates, ps...)
+	return _q
 }
 
 // Limit the number of records to be returned by this query.
-func (omq *OrgMembershipQuery) Limit(limit int) *OrgMembershipQuery {
-	omq.ctx.Limit = &limit
-	return omq
+func (_q *OrgMembershipQuery) Limit(limit int) *OrgMembershipQuery {
+	_q.ctx.Limit = &limit
+	return _q
 }
 
 // Offset to start from.
-func (omq *OrgMembershipQuery) Offset(offset int) *OrgMembershipQuery {
-	omq.ctx.Offset = &offset
-	return omq
+func (_q *OrgMembershipQuery) Offset(offset int) *OrgMembershipQuery {
+	_q.ctx.Offset = &offset
+	return _q
 }
 
 // Unique configures the query builder to filter duplicate records on query.
 // By default, unique is set to true, and can be disabled using this method.
-func (omq *OrgMembershipQuery) Unique(unique bool) *OrgMembershipQuery {
-	omq.ctx.Unique = &unique
-	return omq
+func (_q *OrgMembershipQuery) Unique(unique bool) *OrgMembershipQuery {
+	_q.ctx.Unique = &unique
+	return _q
 }
 
 // Order specifies how the records should be ordered.
-func (omq *OrgMembershipQuery) Order(o ...orgmembership.OrderOption) *OrgMembershipQuery {
-	omq.order = append(omq.order, o...)
-	return omq
+func (_q *OrgMembershipQuery) Order(o ...orgmembership.OrderOption) *OrgMembershipQuery {
+	_q.order = append(_q.order, o...)
+	return _q
 }
 
 // QueryOrganization chains the current query on the "organization" edge.
-func (omq *OrgMembershipQuery) QueryOrganization() *OrganizationQuery {
-	query := (&OrganizationClient{config: omq.config}).Query()
+func (_q *OrgMembershipQuery) QueryOrganization() *OrganizationQuery {
+	query := (&OrganizationClient{config: _q.config}).Query()
 	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
-		if err := omq.prepareQuery(ctx); err != nil {
+		if err := _q.prepareQuery(ctx); err != nil {
 			return nil, err
 		}
-		selector := omq.sqlQuery(ctx)
+		selector := _q.sqlQuery(ctx)
 		if err := selector.Err(); err != nil {
 			return nil, err
 		}
@@ -78,7 +78,7 @@ func (omq *OrgMembershipQuery) QueryOrganization() *OrganizationQuery {
 			sqlgraph.To(organization.Table, organization.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, orgmembership.OrganizationTable, orgmembership.OrganizationColumn),
 		)
-		fromU = sqlgraph.SetNeighbors(omq.driver.Dialect(), step)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
 	}
 	return query
@@ -86,8 +86,8 @@ func (omq *OrgMembershipQuery) QueryOrganization() *OrganizationQuery {
 
 // First returns the first OrgMembership entity from the query.
 // Returns a *NotFoundError when no OrgMembership was found.
-func (omq *OrgMembershipQuery) First(ctx context.Context) (*OrgMembership, error) {
-	nodes, err := omq.Limit(1).All(setContextOp(ctx, omq.ctx, ent.OpQueryFirst))
+func (_q *OrgMembershipQuery) First(ctx context.Context) (*OrgMembership, error) {
+	nodes, err := _q.Limit(1).All(setContextOp(ctx, _q.ctx, ent.OpQueryFirst))
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +98,8 @@ func (omq *OrgMembershipQuery) First(ctx context.Context) (*OrgMembership, error
 }
 
 // FirstX is like First, but panics if an error occurs.
-func (omq *OrgMembershipQuery) FirstX(ctx context.Context) *OrgMembership {
-	node, err := omq.First(ctx)
+func (_q *OrgMembershipQuery) FirstX(ctx context.Context) *OrgMembership {
+	node, err := _q.First(ctx)
 	if err != nil && !IsNotFound(err) {
 		panic(err)
 	}
@@ -108,9 +108,9 @@ func (omq *OrgMembershipQuery) FirstX(ctx context.Context) *OrgMembership {
 
 // FirstID returns the first OrgMembership ID from the query.
 // Returns a *NotFoundError when no OrgMembership ID was found.
-func (omq *OrgMembershipQuery) FirstID(ctx context.Context) (id string, err error) {
+func (_q *OrgMembershipQuery) FirstID(ctx context.Context) (id string, err error) {
 	var ids []string
-	if ids, err = omq.Limit(1).IDs(setContextOp(ctx, omq.ctx, ent.OpQueryFirstID)); err != nil {
+	if ids, err = _q.Limit(1).IDs(setContextOp(ctx, _q.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
 	if len(ids) == 0 {
@@ -121,8 +121,8 @@ func (omq *OrgMembershipQuery) FirstID(ctx context.Context) (id string, err erro
 }
 
 // FirstIDX is like FirstID, but panics if an error occurs.
-func (omq *OrgMembershipQuery) FirstIDX(ctx context.Context) string {
-	id, err := omq.FirstID(ctx)
+func (_q *OrgMembershipQuery) FirstIDX(ctx context.Context) string {
+	id, err := _q.FirstID(ctx)
 	if err != nil && !IsNotFound(err) {
 		panic(err)
 	}
@@ -132,8 +132,8 @@ func (omq *OrgMembershipQuery) FirstIDX(ctx context.Context) string {
 // Only returns a single OrgMembership entity found by the query, ensuring it only returns one.
 // Returns a *NotSingularError when more than one OrgMembership entity is found.
 // Returns a *NotFoundError when no OrgMembership entities are found.
-func (omq *OrgMembershipQuery) Only(ctx context.Context) (*OrgMembership, error) {
-	nodes, err := omq.Limit(2).All(setContextOp(ctx, omq.ctx, ent.OpQueryOnly))
+func (_q *OrgMembershipQuery) Only(ctx context.Context) (*OrgMembership, error) {
+	nodes, err := _q.Limit(2).All(setContextOp(ctx, _q.ctx, ent.OpQueryOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -148,8 +148,8 @@ func (omq *OrgMembershipQuery) Only(ctx context.Context) (*OrgMembership, error)
 }
 
 // OnlyX is like Only, but panics if an error occurs.
-func (omq *OrgMembershipQuery) OnlyX(ctx context.Context) *OrgMembership {
-	node, err := omq.Only(ctx)
+func (_q *OrgMembershipQuery) OnlyX(ctx context.Context) *OrgMembership {
+	node, err := _q.Only(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -159,9 +159,9 @@ func (omq *OrgMembershipQuery) OnlyX(ctx context.Context) *OrgMembership {
 // OnlyID is like Only, but returns the only OrgMembership ID in the query.
 // Returns a *NotSingularError when more than one OrgMembership ID is found.
 // Returns a *NotFoundError when no entities are found.
-func (omq *OrgMembershipQuery) OnlyID(ctx context.Context) (id string, err error) {
+func (_q *OrgMembershipQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string
-	if ids, err = omq.Limit(2).IDs(setContextOp(ctx, omq.ctx, ent.OpQueryOnlyID)); err != nil {
+	if ids, err = _q.Limit(2).IDs(setContextOp(ctx, _q.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
 	switch len(ids) {
@@ -176,8 +176,8 @@ func (omq *OrgMembershipQuery) OnlyID(ctx context.Context) (id string, err error
 }
 
 // OnlyIDX is like OnlyID, but panics if an error occurs.
-func (omq *OrgMembershipQuery) OnlyIDX(ctx context.Context) string {
-	id, err := omq.OnlyID(ctx)
+func (_q *OrgMembershipQuery) OnlyIDX(ctx context.Context) string {
+	id, err := _q.OnlyID(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -185,18 +185,18 @@ func (omq *OrgMembershipQuery) OnlyIDX(ctx context.Context) string {
 }
 
 // All executes the query and returns a list of OrgMemberships.
-func (omq *OrgMembershipQuery) All(ctx context.Context) ([]*OrgMembership, error) {
-	ctx = setContextOp(ctx, omq.ctx, ent.OpQueryAll)
-	if err := omq.prepareQuery(ctx); err != nil {
+func (_q *OrgMembershipQuery) All(ctx context.Context) ([]*OrgMembership, error) {
+	ctx = setContextOp(ctx, _q.ctx, ent.OpQueryAll)
+	if err := _q.prepareQuery(ctx); err != nil {
 		return nil, err
 	}
 	qr := querierAll[[]*OrgMembership, *OrgMembershipQuery]()
-	return withInterceptors[[]*OrgMembership](ctx, omq, qr, omq.inters)
+	return withInterceptors[[]*OrgMembership](ctx, _q, qr, _q.inters)
 }
 
 // AllX is like All, but panics if an error occurs.
-func (omq *OrgMembershipQuery) AllX(ctx context.Context) []*OrgMembership {
-	nodes, err := omq.All(ctx)
+func (_q *OrgMembershipQuery) AllX(ctx context.Context) []*OrgMembership {
+	nodes, err := _q.All(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -204,20 +204,20 @@ func (omq *OrgMembershipQuery) AllX(ctx context.Context) []*OrgMembership {
 }
 
 // IDs executes the query and returns a list of OrgMembership IDs.
-func (omq *OrgMembershipQuery) IDs(ctx context.Context) (ids []string, err error) {
-	if omq.ctx.Unique == nil && omq.path != nil {
-		omq.Unique(true)
+func (_q *OrgMembershipQuery) IDs(ctx context.Context) (ids []string, err error) {
+	if _q.ctx.Unique == nil && _q.path != nil {
+		_q.Unique(true)
 	}
-	ctx = setContextOp(ctx, omq.ctx, ent.OpQueryIDs)
-	if err = omq.Select(orgmembership.FieldID).Scan(ctx, &ids); err != nil {
+	ctx = setContextOp(ctx, _q.ctx, ent.OpQueryIDs)
+	if err = _q.Select(orgmembership.FieldID).Scan(ctx, &ids); err != nil {
 		return nil, err
 	}
 	return ids, nil
 }
 
 // IDsX is like IDs, but panics if an error occurs.
-func (omq *OrgMembershipQuery) IDsX(ctx context.Context) []string {
-	ids, err := omq.IDs(ctx)
+func (_q *OrgMembershipQuery) IDsX(ctx context.Context) []string {
+	ids, err := _q.IDs(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -225,17 +225,17 @@ func (omq *OrgMembershipQuery) IDsX(ctx context.Context) []string {
 }
 
 // Count returns the count of the given query.
-func (omq *OrgMembershipQuery) Count(ctx context.Context) (int, error) {
-	ctx = setContextOp(ctx, omq.ctx, ent.OpQueryCount)
-	if err := omq.prepareQuery(ctx); err != nil {
+func (_q *OrgMembershipQuery) Count(ctx context.Context) (int, error) {
+	ctx = setContextOp(ctx, _q.ctx, ent.OpQueryCount)
+	if err := _q.prepareQuery(ctx); err != nil {
 		return 0, err
 	}
-	return withInterceptors[int](ctx, omq, querierCount[*OrgMembershipQuery](), omq.inters)
+	return withInterceptors[int](ctx, _q, querierCount[*OrgMembershipQuery](), _q.inters)
 }
 
 // CountX is like Count, but panics if an error occurs.
-func (omq *OrgMembershipQuery) CountX(ctx context.Context) int {
-	count, err := omq.Count(ctx)
+func (_q *OrgMembershipQuery) CountX(ctx context.Context) int {
+	count, err := _q.Count(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -243,9 +243,9 @@ func (omq *OrgMembershipQuery) CountX(ctx context.Context) int {
 }
 
 // Exist returns true if the query has elements in the graph.
-func (omq *OrgMembershipQuery) Exist(ctx context.Context) (bool, error) {
-	ctx = setContextOp(ctx, omq.ctx, ent.OpQueryExist)
-	switch _, err := omq.FirstID(ctx); {
+func (_q *OrgMembershipQuery) Exist(ctx context.Context) (bool, error) {
+	ctx = setContextOp(ctx, _q.ctx, ent.OpQueryExist)
+	switch _, err := _q.FirstID(ctx); {
 	case IsNotFound(err):
 		return false, nil
 	case err != nil:
@@ -256,8 +256,8 @@ func (omq *OrgMembershipQuery) Exist(ctx context.Context) (bool, error) {
 }
 
 // ExistX is like Exist, but panics if an error occurs.
-func (omq *OrgMembershipQuery) ExistX(ctx context.Context) bool {
-	exist, err := omq.Exist(ctx)
+func (_q *OrgMembershipQuery) ExistX(ctx context.Context) bool {
+	exist, err := _q.Exist(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -266,32 +266,32 @@ func (omq *OrgMembershipQuery) ExistX(ctx context.Context) bool {
 
 // Clone returns a duplicate of the OrgMembershipQuery builder, including all associated steps. It can be
 // used to prepare common query builders and use them differently after the clone is made.
-func (omq *OrgMembershipQuery) Clone() *OrgMembershipQuery {
-	if omq == nil {
+func (_q *OrgMembershipQuery) Clone() *OrgMembershipQuery {
+	if _q == nil {
 		return nil
 	}
 	return &OrgMembershipQuery{
-		config:           omq.config,
-		ctx:              omq.ctx.Clone(),
-		order:            append([]orgmembership.OrderOption{}, omq.order...),
-		inters:           append([]Interceptor{}, omq.inters...),
-		predicates:       append([]predicate.OrgMembership{}, omq.predicates...),
-		withOrganization: omq.withOrganization.Clone(),
+		config:           _q.config,
+		ctx:              _q.ctx.Clone(),
+		order:            append([]orgmembership.OrderOption{}, _q.order...),
+		inters:           append([]Interceptor{}, _q.inters...),
+		predicates:       append([]predicate.OrgMembership{}, _q.predicates...),
+		withOrganization: _q.withOrganization.Clone(),
 		// clone intermediate query.
-		sql:  omq.sql.Clone(),
-		path: omq.path,
+		sql:  _q.sql.Clone(),
+		path: _q.path,
 	}
 }
 
 // WithOrganization tells the query-builder to eager-load the nodes that are connected to
 // the "organization" edge. The optional arguments are used to configure the query builder of the edge.
-func (omq *OrgMembershipQuery) WithOrganization(opts ...func(*OrganizationQuery)) *OrgMembershipQuery {
-	query := (&OrganizationClient{config: omq.config}).Query()
+func (_q *OrgMembershipQuery) WithOrganization(opts ...func(*OrganizationQuery)) *OrgMembershipQuery {
+	query := (&OrganizationClient{config: _q.config}).Query()
 	for _, opt := range opts {
 		opt(query)
 	}
-	omq.withOrganization = query
-	return omq
+	_q.withOrganization = query
+	return _q
 }
 
 // GroupBy is used to group vertices by one or more fields/columns.
@@ -308,10 +308,10 @@ func (omq *OrgMembershipQuery) WithOrganization(opts ...func(*OrganizationQuery)
 //		GroupBy(orgmembership.FieldRole).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
-func (omq *OrgMembershipQuery) GroupBy(field string, fields ...string) *OrgMembershipGroupBy {
-	omq.ctx.Fields = append([]string{field}, fields...)
-	grbuild := &OrgMembershipGroupBy{build: omq}
-	grbuild.flds = &omq.ctx.Fields
+func (_q *OrgMembershipQuery) GroupBy(field string, fields ...string) *OrgMembershipGroupBy {
+	_q.ctx.Fields = append([]string{field}, fields...)
+	grbuild := &OrgMembershipGroupBy{build: _q}
+	grbuild.flds = &_q.ctx.Fields
 	grbuild.label = orgmembership.Label
 	grbuild.scan = grbuild.Scan
 	return grbuild
@@ -329,89 +329,89 @@ func (omq *OrgMembershipQuery) GroupBy(field string, fields ...string) *OrgMembe
 //	client.OrgMembership.Query().
 //		Select(orgmembership.FieldRole).
 //		Scan(ctx, &v)
-func (omq *OrgMembershipQuery) Select(fields ...string) *OrgMembershipSelect {
-	omq.ctx.Fields = append(omq.ctx.Fields, fields...)
-	sbuild := &OrgMembershipSelect{OrgMembershipQuery: omq}
+func (_q *OrgMembershipQuery) Select(fields ...string) *OrgMembershipSelect {
+	_q.ctx.Fields = append(_q.ctx.Fields, fields...)
+	sbuild := &OrgMembershipSelect{OrgMembershipQuery: _q}
 	sbuild.label = orgmembership.Label
-	sbuild.flds, sbuild.scan = &omq.ctx.Fields, sbuild.Scan
+	sbuild.flds, sbuild.scan = &_q.ctx.Fields, sbuild.Scan
 	return sbuild
 }
 
 // Aggregate returns a OrgMembershipSelect configured with the given aggregations.
-func (omq *OrgMembershipQuery) Aggregate(fns ...AggregateFunc) *OrgMembershipSelect {
-	return omq.Select().Aggregate(fns...)
+func (_q *OrgMembershipQuery) Aggregate(fns ...AggregateFunc) *OrgMembershipSelect {
+	return _q.Select().Aggregate(fns...)
 }
 
-func (omq *OrgMembershipQuery) prepareQuery(ctx context.Context) error {
-	for _, inter := range omq.inters {
+func (_q *OrgMembershipQuery) prepareQuery(ctx context.Context) error {
+	for _, inter := range _q.inters {
 		if inter == nil {
 			return fmt.Errorf("ent: uninitialized interceptor (forgotten import ent/runtime?)")
 		}
 		if trv, ok := inter.(Traverser); ok {
-			if err := trv.Traverse(ctx, omq); err != nil {
+			if err := trv.Traverse(ctx, _q); err != nil {
 				return err
 			}
 		}
 	}
-	for _, f := range omq.ctx.Fields {
+	for _, f := range _q.ctx.Fields {
 		if !orgmembership.ValidColumn(f) {
 			return &ValidationError{Name: f, err: fmt.Errorf("ent: invalid field %q for query", f)}
 		}
 	}
-	if omq.path != nil {
-		prev, err := omq.path(ctx)
+	if _q.path != nil {
+		prev, err := _q.path(ctx)
 		if err != nil {
 			return err
 		}
-		omq.sql = prev
+		_q.sql = prev
 	}
 	return nil
 }
 
-func (omq *OrgMembershipQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*OrgMembership, error) {
+func (_q *OrgMembershipQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*OrgMembership, error) {
 	var (
 		nodes       = []*OrgMembership{}
-		_spec       = omq.querySpec()
+		_spec       = _q.querySpec()
 		loadedTypes = [1]bool{
-			omq.withOrganization != nil,
+			_q.withOrganization != nil,
 		}
 	)
 	_spec.ScanValues = func(columns []string) ([]any, error) {
 		return (*OrgMembership).scanValues(nil, columns)
 	}
 	_spec.Assign = func(columns []string, values []any) error {
-		node := &OrgMembership{config: omq.config}
+		node := &OrgMembership{config: _q.config}
 		nodes = append(nodes, node)
 		node.Edges.loadedTypes = loadedTypes
 		return node.assignValues(columns, values)
 	}
-	if len(omq.modifiers) > 0 {
-		_spec.Modifiers = omq.modifiers
+	if len(_q.modifiers) > 0 {
+		_spec.Modifiers = _q.modifiers
 	}
 	for i := range hooks {
 		hooks[i](ctx, _spec)
 	}
-	if err := sqlgraph.QueryNodes(ctx, omq.driver, _spec); err != nil {
+	if err := sqlgraph.QueryNodes(ctx, _q.driver, _spec); err != nil {
 		return nil, err
 	}
 	if len(nodes) == 0 {
 		return nodes, nil
 	}
-	if query := omq.withOrganization; query != nil {
-		if err := omq.loadOrganization(ctx, query, nodes, nil,
+	if query := _q.withOrganization; query != nil {
+		if err := _q.loadOrganization(ctx, query, nodes, nil,
 			func(n *OrgMembership, e *Organization) { n.Edges.Organization = e }); err != nil {
 			return nil, err
 		}
 	}
-	for i := range omq.loadTotal {
-		if err := omq.loadTotal[i](ctx, nodes); err != nil {
+	for i := range _q.loadTotal {
+		if err := _q.loadTotal[i](ctx, nodes); err != nil {
 			return nil, err
 		}
 	}
 	return nodes, nil
 }
 
-func (omq *OrgMembershipQuery) loadOrganization(ctx context.Context, query *OrganizationQuery, nodes []*OrgMembership, init func(*OrgMembership), assign func(*OrgMembership, *Organization)) error {
+func (_q *OrgMembershipQuery) loadOrganization(ctx context.Context, query *OrganizationQuery, nodes []*OrgMembership, init func(*OrgMembership), assign func(*OrgMembership, *Organization)) error {
 	ids := make([]string, 0, len(nodes))
 	nodeids := make(map[string][]*OrgMembership)
 	for i := range nodes {
@@ -441,27 +441,27 @@ func (omq *OrgMembershipQuery) loadOrganization(ctx context.Context, query *Orga
 	return nil
 }
 
-func (omq *OrgMembershipQuery) sqlCount(ctx context.Context) (int, error) {
-	_spec := omq.querySpec()
-	if len(omq.modifiers) > 0 {
-		_spec.Modifiers = omq.modifiers
+func (_q *OrgMembershipQuery) sqlCount(ctx context.Context) (int, error) {
+	_spec := _q.querySpec()
+	if len(_q.modifiers) > 0 {
+		_spec.Modifiers = _q.modifiers
 	}
-	_spec.Node.Columns = omq.ctx.Fields
-	if len(omq.ctx.Fields) > 0 {
-		_spec.Unique = omq.ctx.Unique != nil && *omq.ctx.Unique
+	_spec.Node.Columns = _q.ctx.Fields
+	if len(_q.ctx.Fields) > 0 {
+		_spec.Unique = _q.ctx.Unique != nil && *_q.ctx.Unique
 	}
-	return sqlgraph.CountNodes(ctx, omq.driver, _spec)
+	return sqlgraph.CountNodes(ctx, _q.driver, _spec)
 }
 
-func (omq *OrgMembershipQuery) querySpec() *sqlgraph.QuerySpec {
+func (_q *OrgMembershipQuery) querySpec() *sqlgraph.QuerySpec {
 	_spec := sqlgraph.NewQuerySpec(orgmembership.Table, orgmembership.Columns, sqlgraph.NewFieldSpec(orgmembership.FieldID, field.TypeString))
-	_spec.From = omq.sql
-	if unique := omq.ctx.Unique; unique != nil {
+	_spec.From = _q.sql
+	if unique := _q.ctx.Unique; unique != nil {
 		_spec.Unique = *unique
-	} else if omq.path != nil {
+	} else if _q.path != nil {
 		_spec.Unique = true
 	}
-	if fields := omq.ctx.Fields; len(fields) > 0 {
+	if fields := _q.ctx.Fields; len(fields) > 0 {
 		_spec.Node.Columns = make([]string, 0, len(fields))
 		_spec.Node.Columns = append(_spec.Node.Columns, orgmembership.FieldID)
 		for i := range fields {
@@ -469,24 +469,24 @@ func (omq *OrgMembershipQuery) querySpec() *sqlgraph.QuerySpec {
 				_spec.Node.Columns = append(_spec.Node.Columns, fields[i])
 			}
 		}
-		if omq.withOrganization != nil {
+		if _q.withOrganization != nil {
 			_spec.Node.AddColumnOnce(orgmembership.FieldOrganizationID)
 		}
 	}
-	if ps := omq.predicates; len(ps) > 0 {
+	if ps := _q.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	if limit := omq.ctx.Limit; limit != nil {
+	if limit := _q.ctx.Limit; limit != nil {
 		_spec.Limit = *limit
 	}
-	if offset := omq.ctx.Offset; offset != nil {
+	if offset := _q.ctx.Offset; offset != nil {
 		_spec.Offset = *offset
 	}
-	if ps := omq.order; len(ps) > 0 {
+	if ps := _q.order; len(ps) > 0 {
 		_spec.Order = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
@@ -496,33 +496,33 @@ func (omq *OrgMembershipQuery) querySpec() *sqlgraph.QuerySpec {
 	return _spec
 }
 
-func (omq *OrgMembershipQuery) sqlQuery(ctx context.Context) *sql.Selector {
-	builder := sql.Dialect(omq.driver.Dialect())
+func (_q *OrgMembershipQuery) sqlQuery(ctx context.Context) *sql.Selector {
+	builder := sql.Dialect(_q.driver.Dialect())
 	t1 := builder.Table(orgmembership.Table)
-	columns := omq.ctx.Fields
+	columns := _q.ctx.Fields
 	if len(columns) == 0 {
 		columns = orgmembership.Columns
 	}
 	selector := builder.Select(t1.Columns(columns...)...).From(t1)
-	if omq.sql != nil {
-		selector = omq.sql
+	if _q.sql != nil {
+		selector = _q.sql
 		selector.Select(selector.Columns(columns...)...)
 	}
-	if omq.ctx.Unique != nil && *omq.ctx.Unique {
+	if _q.ctx.Unique != nil && *_q.ctx.Unique {
 		selector.Distinct()
 	}
-	for _, p := range omq.predicates {
+	for _, p := range _q.predicates {
 		p(selector)
 	}
-	for _, p := range omq.order {
+	for _, p := range _q.order {
 		p(selector)
 	}
-	if offset := omq.ctx.Offset; offset != nil {
+	if offset := _q.ctx.Offset; offset != nil {
 		// limit is mandatory for offset clause. We start
 		// with default value, and override it below if needed.
 		selector.Offset(*offset).Limit(math.MaxInt32)
 	}
-	if limit := omq.ctx.Limit; limit != nil {
+	if limit := _q.ctx.Limit; limit != nil {
 		selector.Limit(*limit)
 	}
 	return selector
@@ -535,41 +535,41 @@ type OrgMembershipGroupBy struct {
 }
 
 // Aggregate adds the given aggregation functions to the group-by query.
-func (omgb *OrgMembershipGroupBy) Aggregate(fns ...AggregateFunc) *OrgMembershipGroupBy {
-	omgb.fns = append(omgb.fns, fns...)
-	return omgb
+func (_g *OrgMembershipGroupBy) Aggregate(fns ...AggregateFunc) *OrgMembershipGroupBy {
+	_g.fns = append(_g.fns, fns...)
+	return _g
 }
 
 // Scan applies the selector query and scans the result into the given value.
-func (omgb *OrgMembershipGroupBy) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, omgb.build.ctx, ent.OpQueryGroupBy)
-	if err := omgb.build.prepareQuery(ctx); err != nil {
+func (_g *OrgMembershipGroupBy) Scan(ctx context.Context, v any) error {
+	ctx = setContextOp(ctx, _g.build.ctx, ent.OpQueryGroupBy)
+	if err := _g.build.prepareQuery(ctx); err != nil {
 		return err
 	}
-	return scanWithInterceptors[*OrgMembershipQuery, *OrgMembershipGroupBy](ctx, omgb.build, omgb, omgb.build.inters, v)
+	return scanWithInterceptors[*OrgMembershipQuery, *OrgMembershipGroupBy](ctx, _g.build, _g, _g.build.inters, v)
 }
 
-func (omgb *OrgMembershipGroupBy) sqlScan(ctx context.Context, root *OrgMembershipQuery, v any) error {
+func (_g *OrgMembershipGroupBy) sqlScan(ctx context.Context, root *OrgMembershipQuery, v any) error {
 	selector := root.sqlQuery(ctx).Select()
-	aggregation := make([]string, 0, len(omgb.fns))
-	for _, fn := range omgb.fns {
+	aggregation := make([]string, 0, len(_g.fns))
+	for _, fn := range _g.fns {
 		aggregation = append(aggregation, fn(selector))
 	}
 	if len(selector.SelectedColumns()) == 0 {
-		columns := make([]string, 0, len(*omgb.flds)+len(omgb.fns))
-		for _, f := range *omgb.flds {
+		columns := make([]string, 0, len(*_g.flds)+len(_g.fns))
+		for _, f := range *_g.flds {
 			columns = append(columns, selector.C(f))
 		}
 		columns = append(columns, aggregation...)
 		selector.Select(columns...)
 	}
-	selector.GroupBy(selector.Columns(*omgb.flds...)...)
+	selector.GroupBy(selector.Columns(*_g.flds...)...)
 	if err := selector.Err(); err != nil {
 		return err
 	}
 	rows := &sql.Rows{}
 	query, args := selector.Query()
-	if err := omgb.build.driver.Query(ctx, query, args, rows); err != nil {
+	if err := _g.build.driver.Query(ctx, query, args, rows); err != nil {
 		return err
 	}
 	defer rows.Close()
@@ -583,27 +583,27 @@ type OrgMembershipSelect struct {
 }
 
 // Aggregate adds the given aggregation functions to the selector query.
-func (oms *OrgMembershipSelect) Aggregate(fns ...AggregateFunc) *OrgMembershipSelect {
-	oms.fns = append(oms.fns, fns...)
-	return oms
+func (_s *OrgMembershipSelect) Aggregate(fns ...AggregateFunc) *OrgMembershipSelect {
+	_s.fns = append(_s.fns, fns...)
+	return _s
 }
 
 // Scan applies the selector query and scans the result into the given value.
-func (oms *OrgMembershipSelect) Scan(ctx context.Context, v any) error {
-	ctx = setContextOp(ctx, oms.ctx, ent.OpQuerySelect)
-	if err := oms.prepareQuery(ctx); err != nil {
+func (_s *OrgMembershipSelect) Scan(ctx context.Context, v any) error {
+	ctx = setContextOp(ctx, _s.ctx, ent.OpQuerySelect)
+	if err := _s.prepareQuery(ctx); err != nil {
 		return err
 	}
-	return scanWithInterceptors[*OrgMembershipQuery, *OrgMembershipSelect](ctx, oms.OrgMembershipQuery, oms, oms.inters, v)
+	return scanWithInterceptors[*OrgMembershipQuery, *OrgMembershipSelect](ctx, _s.OrgMembershipQuery, _s, _s.inters, v)
 }
 
-func (oms *OrgMembershipSelect) sqlScan(ctx context.Context, root *OrgMembershipQuery, v any) error {
+func (_s *OrgMembershipSelect) sqlScan(ctx context.Context, root *OrgMembershipQuery, v any) error {
 	selector := root.sqlQuery(ctx)
-	aggregation := make([]string, 0, len(oms.fns))
-	for _, fn := range oms.fns {
+	aggregation := make([]string, 0, len(_s.fns))
+	for _, fn := range _s.fns {
 		aggregation = append(aggregation, fn(selector))
 	}
-	switch n := len(*oms.selector.flds); {
+	switch n := len(*_s.selector.flds); {
 	case n == 0 && len(aggregation) > 0:
 		selector.Select(aggregation...)
 	case n != 0 && len(aggregation) > 0:
@@ -611,7 +611,7 @@ func (oms *OrgMembershipSelect) sqlScan(ctx context.Context, root *OrgMembership
 	}
 	rows := &sql.Rows{}
 	query, args := selector.Query()
-	if err := oms.driver.Query(ctx, query, args, rows); err != nil {
+	if err := _s.driver.Query(ctx, query, args, rows); err != nil {
 		return err
 	}
 	defer rows.Close()

--- a/vanilla/_example/ent/orgmembership_update.go
+++ b/vanilla/_example/ent/orgmembership_update.go
@@ -23,38 +23,38 @@ type OrgMembershipUpdate struct {
 }
 
 // Where appends a list predicates to the OrgMembershipUpdate builder.
-func (omu *OrgMembershipUpdate) Where(ps ...predicate.OrgMembership) *OrgMembershipUpdate {
-	omu.mutation.Where(ps...)
-	return omu
+func (_u *OrgMembershipUpdate) Where(ps ...predicate.OrgMembership) *OrgMembershipUpdate {
+	_u.mutation.Where(ps...)
+	return _u
 }
 
 // SetRole sets the "role" field.
-func (omu *OrgMembershipUpdate) SetRole(e enums.Role) *OrgMembershipUpdate {
-	omu.mutation.SetRole(e)
-	return omu
+func (_u *OrgMembershipUpdate) SetRole(v enums.Role) *OrgMembershipUpdate {
+	_u.mutation.SetRole(v)
+	return _u
 }
 
 // SetNillableRole sets the "role" field if the given value is not nil.
-func (omu *OrgMembershipUpdate) SetNillableRole(e *enums.Role) *OrgMembershipUpdate {
-	if e != nil {
-		omu.SetRole(*e)
+func (_u *OrgMembershipUpdate) SetNillableRole(v *enums.Role) *OrgMembershipUpdate {
+	if v != nil {
+		_u.SetRole(*v)
 	}
-	return omu
+	return _u
 }
 
 // Mutation returns the OrgMembershipMutation object of the builder.
-func (omu *OrgMembershipUpdate) Mutation() *OrgMembershipMutation {
-	return omu.mutation
+func (_u *OrgMembershipUpdate) Mutation() *OrgMembershipMutation {
+	return _u.mutation
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
-func (omu *OrgMembershipUpdate) Save(ctx context.Context) (int, error) {
-	return withHooks(ctx, omu.sqlSave, omu.mutation, omu.hooks)
+func (_u *OrgMembershipUpdate) Save(ctx context.Context) (int, error) {
+	return withHooks(ctx, _u.sqlSave, _u.mutation, _u.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
-func (omu *OrgMembershipUpdate) SaveX(ctx context.Context) int {
-	affected, err := omu.Save(ctx)
+func (_u *OrgMembershipUpdate) SaveX(ctx context.Context) int {
+	affected, err := _u.Save(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -62,47 +62,47 @@ func (omu *OrgMembershipUpdate) SaveX(ctx context.Context) int {
 }
 
 // Exec executes the query.
-func (omu *OrgMembershipUpdate) Exec(ctx context.Context) error {
-	_, err := omu.Save(ctx)
+func (_u *OrgMembershipUpdate) Exec(ctx context.Context) error {
+	_, err := _u.Save(ctx)
 	return err
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (omu *OrgMembershipUpdate) ExecX(ctx context.Context) {
-	if err := omu.Exec(ctx); err != nil {
+func (_u *OrgMembershipUpdate) ExecX(ctx context.Context) {
+	if err := _u.Exec(ctx); err != nil {
 		panic(err)
 	}
 }
 
 // check runs all checks and user-defined validators on the builder.
-func (omu *OrgMembershipUpdate) check() error {
-	if v, ok := omu.mutation.Role(); ok {
+func (_u *OrgMembershipUpdate) check() error {
+	if v, ok := _u.mutation.Role(); ok {
 		if err := orgmembership.RoleValidator(v); err != nil {
 			return &ValidationError{Name: "role", err: fmt.Errorf(`ent: validator failed for field "OrgMembership.role": %w`, err)}
 		}
 	}
-	if omu.mutation.OrganizationCleared() && len(omu.mutation.OrganizationIDs()) > 0 {
+	if _u.mutation.OrganizationCleared() && len(_u.mutation.OrganizationIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "OrgMembership.organization"`)
 	}
 	return nil
 }
 
-func (omu *OrgMembershipUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	if err := omu.check(); err != nil {
-		return n, err
+func (_u *OrgMembershipUpdate) sqlSave(ctx context.Context) (_node int, err error) {
+	if err := _u.check(); err != nil {
+		return _node, err
 	}
 	_spec := sqlgraph.NewUpdateSpec(orgmembership.Table, orgmembership.Columns, sqlgraph.NewFieldSpec(orgmembership.FieldID, field.TypeString))
-	if ps := omu.mutation.predicates; len(ps) > 0 {
+	if ps := _u.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	if value, ok := omu.mutation.Role(); ok {
+	if value, ok := _u.mutation.Role(); ok {
 		_spec.SetField(orgmembership.FieldRole, field.TypeEnum, value)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, omu.driver, _spec); err != nil {
+	if _node, err = sqlgraph.UpdateNodes(ctx, _u.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{orgmembership.Label}
 		} else if sqlgraph.IsConstraintError(err) {
@@ -110,8 +110,8 @@ func (omu *OrgMembershipUpdate) sqlSave(ctx context.Context) (n int, err error) 
 		}
 		return 0, err
 	}
-	omu.mutation.done = true
-	return n, nil
+	_u.mutation.done = true
+	return _node, nil
 }
 
 // OrgMembershipUpdateOne is the builder for updating a single OrgMembership entity.
@@ -123,45 +123,45 @@ type OrgMembershipUpdateOne struct {
 }
 
 // SetRole sets the "role" field.
-func (omuo *OrgMembershipUpdateOne) SetRole(e enums.Role) *OrgMembershipUpdateOne {
-	omuo.mutation.SetRole(e)
-	return omuo
+func (_u *OrgMembershipUpdateOne) SetRole(v enums.Role) *OrgMembershipUpdateOne {
+	_u.mutation.SetRole(v)
+	return _u
 }
 
 // SetNillableRole sets the "role" field if the given value is not nil.
-func (omuo *OrgMembershipUpdateOne) SetNillableRole(e *enums.Role) *OrgMembershipUpdateOne {
-	if e != nil {
-		omuo.SetRole(*e)
+func (_u *OrgMembershipUpdateOne) SetNillableRole(v *enums.Role) *OrgMembershipUpdateOne {
+	if v != nil {
+		_u.SetRole(*v)
 	}
-	return omuo
+	return _u
 }
 
 // Mutation returns the OrgMembershipMutation object of the builder.
-func (omuo *OrgMembershipUpdateOne) Mutation() *OrgMembershipMutation {
-	return omuo.mutation
+func (_u *OrgMembershipUpdateOne) Mutation() *OrgMembershipMutation {
+	return _u.mutation
 }
 
 // Where appends a list predicates to the OrgMembershipUpdate builder.
-func (omuo *OrgMembershipUpdateOne) Where(ps ...predicate.OrgMembership) *OrgMembershipUpdateOne {
-	omuo.mutation.Where(ps...)
-	return omuo
+func (_u *OrgMembershipUpdateOne) Where(ps ...predicate.OrgMembership) *OrgMembershipUpdateOne {
+	_u.mutation.Where(ps...)
+	return _u
 }
 
 // Select allows selecting one or more fields (columns) of the returned entity.
 // The default is selecting all fields defined in the entity schema.
-func (omuo *OrgMembershipUpdateOne) Select(field string, fields ...string) *OrgMembershipUpdateOne {
-	omuo.fields = append([]string{field}, fields...)
-	return omuo
+func (_u *OrgMembershipUpdateOne) Select(field string, fields ...string) *OrgMembershipUpdateOne {
+	_u.fields = append([]string{field}, fields...)
+	return _u
 }
 
 // Save executes the query and returns the updated OrgMembership entity.
-func (omuo *OrgMembershipUpdateOne) Save(ctx context.Context) (*OrgMembership, error) {
-	return withHooks(ctx, omuo.sqlSave, omuo.mutation, omuo.hooks)
+func (_u *OrgMembershipUpdateOne) Save(ctx context.Context) (*OrgMembership, error) {
+	return withHooks(ctx, _u.sqlSave, _u.mutation, _u.hooks)
 }
 
 // SaveX is like Save, but panics if an error occurs.
-func (omuo *OrgMembershipUpdateOne) SaveX(ctx context.Context) *OrgMembership {
-	node, err := omuo.Save(ctx)
+func (_u *OrgMembershipUpdateOne) SaveX(ctx context.Context) *OrgMembership {
+	node, err := _u.Save(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -169,42 +169,42 @@ func (omuo *OrgMembershipUpdateOne) SaveX(ctx context.Context) *OrgMembership {
 }
 
 // Exec executes the query on the entity.
-func (omuo *OrgMembershipUpdateOne) Exec(ctx context.Context) error {
-	_, err := omuo.Save(ctx)
+func (_u *OrgMembershipUpdateOne) Exec(ctx context.Context) error {
+	_, err := _u.Save(ctx)
 	return err
 }
 
 // ExecX is like Exec, but panics if an error occurs.
-func (omuo *OrgMembershipUpdateOne) ExecX(ctx context.Context) {
-	if err := omuo.Exec(ctx); err != nil {
+func (_u *OrgMembershipUpdateOne) ExecX(ctx context.Context) {
+	if err := _u.Exec(ctx); err != nil {
 		panic(err)
 	}
 }
 
 // check runs all checks and user-defined validators on the builder.
-func (omuo *OrgMembershipUpdateOne) check() error {
-	if v, ok := omuo.mutation.Role(); ok {
+func (_u *OrgMembershipUpdateOne) check() error {
+	if v, ok := _u.mutation.Role(); ok {
 		if err := orgmembership.RoleValidator(v); err != nil {
 			return &ValidationError{Name: "role", err: fmt.Errorf(`ent: validator failed for field "OrgMembership.role": %w`, err)}
 		}
 	}
-	if omuo.mutation.OrganizationCleared() && len(omuo.mutation.OrganizationIDs()) > 0 {
+	if _u.mutation.OrganizationCleared() && len(_u.mutation.OrganizationIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "OrgMembership.organization"`)
 	}
 	return nil
 }
 
-func (omuo *OrgMembershipUpdateOne) sqlSave(ctx context.Context) (_node *OrgMembership, err error) {
-	if err := omuo.check(); err != nil {
+func (_u *OrgMembershipUpdateOne) sqlSave(ctx context.Context) (_node *OrgMembership, err error) {
+	if err := _u.check(); err != nil {
 		return _node, err
 	}
 	_spec := sqlgraph.NewUpdateSpec(orgmembership.Table, orgmembership.Columns, sqlgraph.NewFieldSpec(orgmembership.FieldID, field.TypeString))
-	id, ok := omuo.mutation.ID()
+	id, ok := _u.mutation.ID()
 	if !ok {
 		return nil, &ValidationError{Name: "id", err: errors.New(`ent: missing "OrgMembership.id" for update`)}
 	}
 	_spec.Node.ID.Value = id
-	if fields := omuo.fields; len(fields) > 0 {
+	if fields := _u.fields; len(fields) > 0 {
 		_spec.Node.Columns = make([]string, 0, len(fields))
 		_spec.Node.Columns = append(_spec.Node.Columns, orgmembership.FieldID)
 		for _, f := range fields {
@@ -216,20 +216,20 @@ func (omuo *OrgMembershipUpdateOne) sqlSave(ctx context.Context) (_node *OrgMemb
 			}
 		}
 	}
-	if ps := omuo.mutation.predicates; len(ps) > 0 {
+	if ps := _u.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	if value, ok := omuo.mutation.Role(); ok {
+	if value, ok := _u.mutation.Role(); ok {
 		_spec.SetField(orgmembership.FieldRole, field.TypeEnum, value)
 	}
-	_node = &OrgMembership{config: omuo.config}
+	_node = &OrgMembership{config: _u.config}
 	_spec.Assign = _node.assignValues
 	_spec.ScanValues = _node.scanValues
-	if err = sqlgraph.UpdateNode(ctx, omuo.driver, _spec); err != nil {
+	if err = sqlgraph.UpdateNode(ctx, _u.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{orgmembership.Label}
 		} else if sqlgraph.IsConstraintError(err) {
@@ -237,6 +237,6 @@ func (omuo *OrgMembershipUpdateOne) sqlSave(ctx context.Context) (_node *OrgMemb
 		}
 		return nil, err
 	}
-	omuo.mutation.done = true
+	_u.mutation.done = true
 	return _node, nil
 }

--- a/vanilla/_example/ent/runtime/runtime.go
+++ b/vanilla/_example/ent/runtime/runtime.go
@@ -51,6 +51,6 @@ func init() {
 }
 
 const (
-	Version = "v0.14.4"                                         // Version of ent codegen.
-	Sum     = "h1:/DhDraSLXIkBhyiVoJeSshr4ZYi7femzhj6/TckzZuI=" // Sum of ent codegen.
+	Version = "v0.14.5"                                         // Version of ent codegen.
+	Sum     = "h1:Rj2WOYJtCkWyFo6a+5wB3EfBRP0rnx1fMk6gGA0UUe4=" // Sum of ent codegen.
 )


### PR DESCRIPTION
- converting to lowercase, we break the ability to determine the correct graphql name for multi word objects, e.g. InternalPolicy
- regen example, changes related to other things