### PR TITLE
fix: history hook after schema hook updates to mutation

### DIFF
--- a/history/hook.go
+++ b/history/hook.go
@@ -85,11 +85,16 @@ func historyHookUpdate[T Mutation]() ent.Hook {
 				return nil, err
 			}
 
+			value, err := next.Mutate(ctx, m)
+			if err != nil {
+				return nil, err
+			}
+
 			if err = mutation.CreateHistoryFromUpdate(ctx); err != nil {
 				return nil, err
 			}
 
-			return next.Mutate(ctx, m)
+			return value, nil
 		})
 	}
 }
@@ -103,11 +108,16 @@ func historyHookDelete[T Mutation]() ent.Hook {
 				return nil, err
 			}
 
+			value, err := next.Mutate(ctx, m)
+			if err != nil {
+				return nil, err
+			}
+
 			if err = mutation.CreateHistoryFromDelete(ctx); err != nil {
 				return nil, err
 			}
 
-			return next.Mutate(ctx, m)
+			return value, nil
 		})
 	}
 }


### PR DESCRIPTION
I noticed an "off-by-one" issue in our history tables, where on the internal policy history we would have the old revision, but the new details; this is because hooks are order:
```
runtime (history)
schema hooks (hooks in internal/ent/hooks are all mostly schema hooks)

next.Mutate

runtime 
schema
```

The history create hook was correctly setup to do after next.Mutate, but update and delete we setup to do _before_ next.Mutate so they happened before the schema hooks set some values on the mutation.  This should fix the ordering and have the correct values. 