### PR TITLE
fix: history has to run before on delete

### DIFF
--- a/history/hook.go
+++ b/history/hook.go
@@ -108,16 +108,11 @@ func historyHookDelete[T Mutation]() ent.Hook {
 				return nil, err
 			}
 
-			value, err := next.Mutate(ctx, m)
-			if err != nil {
-				return nil, err
-			}
-
 			if err = mutation.CreateHistoryFromDelete(ctx); err != nil {
 				return nil, err
 			}
 
-			return value, nil
+			return next.Mutate(ctx, m)
 		})
 	}
 }


### PR DESCRIPTION
reverts the delete change; this needs to happen after mutation on update; on delete it can happen before since values are not changing. 

Core tests pass locally with this change:
```
DONE 5370 tests, 1 skipped in 212.350s
```