### PR TITLE
always put integration owner id inside ctx

### DIFF
--- a/integrationmapping/extension.go
+++ b/integrationmapping/extension.go
@@ -35,6 +35,8 @@ type Config struct {
 	LoPackage string
 	// JsonxPackage is the jsonx package import path
 	JsonxPackage string
+	// AuthPackage is the auth package import path used for scoping generated ingest persistence
+	AuthPackage string
 }
 
 // Extension implements entc.Extension for integration mapping generation
@@ -139,6 +141,13 @@ func WithLoPackage(path string) ExtensionOption {
 func WithJsonxPackage(path string) ExtensionOption {
 	return func(c *Config) {
 		c.JsonxPackage = path
+	}
+}
+
+// WithAuthPackage sets the auth package import path
+func WithAuthPackage(path string) ExtensionOption {
+	return func(c *Config) {
+		c.AuthPackage = path
 	}
 }
 

--- a/integrationmapping/templates/ingest_listeners.tpl
+++ b/integrationmapping/templates/ingest_listeners.tpl
@@ -9,6 +9,7 @@ import (
 	"{{ .DoPackage }}"
 	"{{ .LoPackage }}"
 
+	"{{ .AuthPackage }}"
 	ent "{{ .EntPackage }}"
 	"{{ .IntegrationGeneratedPackage }}"
 	"{{ .GalaPackage }}"
@@ -175,7 +176,24 @@ func handleIngestRequested[TInput any](
 		return err
 	}
 
-	return persist(ctx.Context, db, integration, input)
+	persistCtx, err := setIntegrationOwnerInContext(ctx.Context, integration.OwnerID)
+	if err != nil {
+		return err
+	}
+
+	return persist(persistCtx, db, integration, input)
+}
+
+func setIntegrationOwnerInContext(ctx context.Context, ownerID string) (context.Context, error) {
+	caller, ok := auth.CallerFromContext(ctx)
+	if !ok || caller == nil {
+		return ctx, auth.ErrNoAuthUser
+	}
+
+	scoped := *caller
+	scoped.OrganizationID = ownerID
+
+	return auth.WithCaller(ctx, &scoped), nil
 }
 
 // buildSchemaRegistration assembles one ingest schema registration from shared generic helpers and schema-specific closures.


### PR DESCRIPTION
this is useful as custom enums fetch the owner id from the ctx and use that to decide if to autocreate the enum

https://github.com/theopenlane/core/blob/9ccaa177cc397f29c2c237ce0c0260a03f7c79cf/internal/ent/hooks/customenums.go#L165-L168
