### PR TITLE
feat: always immutable, no updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,18 +203,12 @@ the older history, the newer history, and the changes to fields when comparing t
 
 enthistory provides several configuration options to customize its behavior.
 
-#### Setting All Tracked Fields as Nillable and/or Immutable
+#### Immutable Tracked Fields
 
-By default, enthistory does not modify the columns in the history tables that are being tracked from your original
-tables; it simply copies their state from ent when loading them.
-
-However, you may want to set all tracked fields in the history tables as either `Nillable` or `Immutable` for various
-reasons. You can use the `enthistory.WithNillableFields()` option to set them all as `Nillable`,
-or `enthistory.WithImmutableFields()` to set them all as `Immutable`.
-
-**Note:** Setting `enthistory.WithNillableFields()` will remove the ability to call the `Restore()` function on a
-history object. Setting all fields to `Nillable` causes the history tables to diverge from the original tables, and the
-unpredictability of that means the `Restore()` function cannot be generated.
+History rows are insert only: they are written once by the mutation hook and never updated. Every
+tracked field copied from your original table is therefore generated as `Immutable`, and any
+`UpdateDefault` on a copied field is cleared so a snapshot column keeps the value it was written
+with. This removes the update builders for the history types entirely.
 
 #### History Time Indexing
 

--- a/history/README.md
+++ b/history/README.md
@@ -187,18 +187,12 @@ the older history, the newer history, and the changes to fields when comparing t
 
 history provides several configuration options to customize its behavior.
 
-### Setting All Tracked Fields as Nillable and/or Immutable
+### Immutable Tracked Fields
 
-By default, history does not modify the columns in the history tables that are being tracked from your original
-tables; it simply copies their state from ent when loading them.
-
-However, you may want to set all tracked fields in the history tables as either `Nillable` or `Immutable` for various
-reasons. You can use the `history.WithNillableFields()` option to set them all as `Nillable`,
-or `history.WithImmutableFields()` to set them all as `Immutable`.
-
-**Note:** Setting `history.WithNillableFields()` will remove the ability to call the `Restore()` function on a
-history object. Setting all fields to `Nillable` causes the history tables to diverge from the original tables, and the
-unpredictability of that means the `Restore()` function cannot be generated.
+History rows are insert only: they are written once by the mutation hook and never updated. Every
+tracked field copied from your original table is therefore generated as `Immutable`, and any
+`UpdateDefault` on a copied field is cleared so a snapshot column keeps the value it was written
+with. This removes the update builders for the history types entirely.
 
 ### History Time Indexing
 

--- a/history/enthistory.go
+++ b/history/enthistory.go
@@ -20,14 +20,6 @@ type UpdatedBy struct {
 	Nillable bool
 }
 
-// FieldProperties is a struct that holds the properties for the fields in the history schema
-type FieldProperties struct {
-	// Nillable indicates if the fields should be nillable
-	Nillable bool
-	// Immutable indicates if the fields should be immutable (not allowed to be updated)
-	Immutable bool
-}
-
 // Config is the configuration for the history extension
 type Config struct {
 	// IncludeUpdatedBy optionally adds an updated_by field to the history schema
@@ -50,8 +42,6 @@ type Config struct {
 	Query bool
 	// Skipper is an optional function name to use as a skipper for history tracking
 	Skipper string
-	// FieldProperties holds the properties for the fields in the history schema
-	FieldProperties *FieldProperties
 	// HistoryTimeIndex tells the extension to add an index to the history_time field
 	HistoryTimeIndex bool
 	// Auth includes the authz policy settings
@@ -90,7 +80,6 @@ func New(opts ...ExtensionOption) *Extension {
 			OutputSchemaPath: defaultSchemaPath,
 			Auditing:         false,
 			PackageName:      defaultPackageName,
-			FieldProperties:  &FieldProperties{},
 		},
 	}
 
@@ -166,25 +155,10 @@ func WithHistoryTimeIndex() ExtensionOption {
 	}
 }
 
-// WithImmutableFields allows you to set all tracked fields in history to Immutable
-func WithImmutableFields() ExtensionOption {
-	return func(h *Extension) {
-		h.config.FieldProperties.Immutable = true
-	}
-}
-
 // WithPackageName allows you to set an alternative package name for the history schema
 func WithPackageName(packageName string) ExtensionOption {
 	return func(h *Extension) {
 		h.config.PackageName = packageName
-	}
-}
-
-// WithNillableFields allows you to set all tracked fields in history to Nillable
-// except enthistory managed fields (history_time, ref, operation, updated_by, & deleted_by)
-func WithNillableFields() ExtensionOption {
-	return func(h *Extension) {
-		h.config.FieldProperties.Nillable = true
 	}
 }
 

--- a/history/template.go
+++ b/history/template.go
@@ -44,11 +44,6 @@ func extractUpdatedByValueType(val any) string {
 	}
 }
 
-// fieldPropertiesNillable checks the config properties for the Nillable setting
-func fieldPropertiesNillable(config Config) bool {
-	return config.FieldProperties != nil && config.FieldProperties.Nillable
-}
-
 // isSlice checks if the string value of the type is prefixed with []
 func isSlice(typeString string) bool {
 	return strings.HasPrefix(typeString, "[]")
@@ -71,7 +66,6 @@ func parseTemplate(name, path string) *gen.Template {
 	t.Funcs(template.FuncMap{
 		"extractUpdatedByKey":       extractUpdatedByKey,
 		"extractUpdatedByValueType": extractUpdatedByValueType,
-		"fieldPropertiesNillable":   fieldPropertiesNillable,
 		"isSlice":                   isSlice,
 		"in":                        in,
 	})

--- a/history/template_test.go
+++ b/history/template_test.go
@@ -85,51 +85,6 @@ func TestExtractUpdatedByValueType(t *testing.T) {
 	}
 }
 
-func TestFieldPropertiesNillable(t *testing.T) {
-	tests := []struct {
-		name   string
-		config Config
-		want   bool
-	}{
-		{
-			name: "nillable true",
-			config: Config{
-				FieldProperties: &FieldProperties{
-					Nillable: true,
-				},
-			},
-			want: true,
-		},
-		{
-			name: "nillable false",
-			config: Config{
-				FieldProperties: &FieldProperties{
-					Nillable: false,
-				},
-			},
-			want: false,
-		},
-		{
-			name: "not set",
-			config: Config{
-				FieldProperties: &FieldProperties{},
-			},
-			want: false,
-		},
-		{
-			name:   "nil config",
-			config: Config{},
-			want:   false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := fieldPropertiesNillable(tt.config)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestIsSlice(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/history/templates/historyQuery.tmpl
+++ b/history/templates/historyQuery.tmpl
@@ -74,7 +74,6 @@ import (
 								First(ctx)
 				}
 
-				{{ if not (fieldPropertiesNillable $.Annotations.HistoryConfig) }}
 				func ({{ $n.Receiver }} *{{ $n.Name }}) Restore(ctx context.Context) (*{{ $n.Name }}, error) {
 					client := New{{ $n.Name }}Client({{ $n.Receiver }}.config)
 					return client.
@@ -86,7 +85,6 @@ import (
 					{{- end }}
 						Save(ctx)
 				}
-				{{ end }}
 			{{ end }}
 		{{ end }}
 	{{ end }}

--- a/history/templates/schema.tmpl
+++ b/history/templates/schema.tmpl
@@ -85,6 +85,13 @@ func ({{ $name }}) Fields() []ent.Field {
 			// make sure the mixed in fields do not have validators
 			field.Descriptor().Validators = nil
 
+			// history rows are insert only, so no tracked field may be updated
+			field.Descriptor().Immutable = true
+
+			// ent still emits a setter for an immutable field that carries an update
+			// default, and a snapshot column must keep the value it was written with
+			field.Descriptor().UpdateDefault = nil
+
 			// append the mixed in field to the history fields
 			historyFields = append(historyFields, field)
 		}
@@ -97,6 +104,13 @@ func ({{ $name }}) Fields() []ent.Field {
 
 		// make sure the mixed in fields do not have validators
 		field.Descriptor().Validators = nil
+
+		// history rows are insert only, so no tracked field may be updated
+		field.Descriptor().Immutable = true
+
+		// ent still emits a setter for an immutable field that carries an update
+		// default, and a snapshot column must keep the value it was written with
+		field.Descriptor().UpdateDefault = nil
 
 		// append the field to the history fields
 		historyFields = append(historyFields, field)


### PR DESCRIPTION
- removes the non-working wrappers for `WithNillableFields` and `WithImmutableFields` and considers all history data immutable; we don't update the rows, we create entries on ops and delete on cleanup. 