### PR TITLE
Include bulk update/deletion fields in model generation

### DIFF
--- a/genhooks/genbulkschema.go
+++ b/genhooks/genbulkschema.go
@@ -271,6 +271,14 @@ type {{ .Name }}BulkUpdatePayload {
     IDs of the updated {{ .Name | ToLowerCamel }}s
     """
     updatedIDs: [ID!]
+    """
+    IDs that were not updated
+    """
+    notUpdatedIDs: [ID!]!
+    """
+    Error message when the bulk update did not apply to every requested ID
+    """
+    error: String
 }
 `
 

--- a/genhooks/templates/graph.tpl
+++ b/genhooks/templates/graph.tpl
@@ -145,6 +145,14 @@ type {{ .Name }}BulkUpdatePayload {
     IDs of the updated {{ .Name | ToLowerCamel }}s
     """
     updatedIDs: [ID!]
+    """
+    IDs that were not updated
+    """
+    notUpdatedIDs: [ID!]!
+    """
+    Error message when the bulk update did not apply to every requested ID
+    """
+    error: String
 }
 
 """


### PR DESCRIPTION
while we fixed in the gql-gen plugin, we didn't add it here https://github.com/theopenlane/gqlgen-plugins/pull/181

and the only reason it wasn't an issue was because we did not make a new schema since then