### PR TITLE
add field sanitization

### DIFF
--- a/entityops/generator.go
+++ b/entityops/generator.go
@@ -156,6 +156,10 @@ type EntityField struct {
 	InputGoField string
 	// LookupKey reports whether the field is the ingest upsert lookup column for its schema
 	LookupKey bool
+	// Sanitizable reports whether ingest preparation pre-validates this mapped field and drops invalid values
+	Sanitizable bool
+	// SliceInput reports whether the field's create-input carrier is a slice rather than a pointer scalar
+	SliceInput bool
 	// DisplayKey reports whether the field is the schema's display-name source
 	DisplayKey bool
 	// Clearable reports whether update inputs support explicitly clearing this field
@@ -338,9 +342,25 @@ func buildEntityField(node *gen.Type, field *gen.Field, integrationFields map[st
 		entityField.InputKey = im.InputKey
 		entityField.InputGoField = im.InputGoField
 		entityField.LookupKey = im.LookupKey
+		entityField.Sanitizable = ingestSanitizable(field, im)
+		entityField.SliceInput = strings.HasPrefix(fieldType, "[]")
 	}
 
 	return entityField, marker, nil
+}
+
+// ingestSanitizable reports whether ingest preparation pre-validates an optional non-lookup mapped
+// field whose generated validator signature matches a plain string or string-slice carrier
+func ingestSanitizable(field *gen.Field, im integrationFieldMeta) bool {
+	if !field.Optional || field.Validators == 0 || im.LookupKey {
+		return false
+	}
+
+	if field.Type == nil || field.HasGoType() {
+		return false
+	}
+
+	return field.Type.Type == entfield.TypeString || field.Type.String() == "[]string"
 }
 
 // collectEntityData iterates the ent graph and collects every primary schema. Optional

--- a/entityops/templates/entity_errors.tpl
+++ b/entityops/templates/entity_errors.tpl
@@ -195,7 +195,17 @@ func logPersistError(ctx context.Context, ref SchemaRef, sentinel error, err err
 // attached via logx.WithField travel on the context logger already, including across durable gala
 // hops, so only the operation context needs explicit embedding
 func errorEvent(ctx context.Context, ref SchemaRef, err error) *zerolog.Event {
-	event := logx.FromContext(ctx).Error().Err(err).EmbedObject(ref)
+	var event *zerolog.Event
+
+	switch {
+	case generated.IsNotFound(err):
+		// a missing row logs at warn since callers uniformly treat not-found as a benign skip
+		event = logx.FromContext(ctx).Warn().Err(err)
+	default:
+		event = logx.FromContext(ctx).Error().Err(err)
+	}
+
+	event = event.EmbedObject(ref)
 
 	oc, ok := gala.OperationContextFromContext(ctx)
 	if !ok {

--- a/entityops/templates/entity_registry.tpl
+++ b/entityops/templates/entity_registry.tpl
@@ -239,6 +239,12 @@ func (s *Schema) PersistIngest(ctx context.Context, client *generated.Client, in
 	return id, applyThroughEdgeIDs(ctx, client, s, id, throughIDs)
 }
 
+// logSanitizedIngestField records one optional mapped field dropped by ingest preparation because
+// its value failed the schema's field validation
+func logSanitizedIngestField(ctx context.Context, schema, field string, err error) {
+	logx.FromContext(ctx).Warn().Err(err).Str(FieldSchema, schema).Str("field", field).Msg("entityops: dropped invalid optional ingest field")
+}
+
 // handleIngest runs the mandatory consumer-side pipeline for one queued mapped entity.
 func (s *Schema) handleIngest(ctx context.Context, client *generated.Client, resolve IngestIntegrationResolver, request IngestRequest) error {
 	ref := SchemaRef{Schema: s.Snake, Operation: refOpCreate}
@@ -841,6 +847,17 @@ var (
 				if err != nil {
 					return nil, logError(ctx, ref, ErrDecodeFailed, err)
 				}
+{{- range $schema.ObjectFields }}
+{{- if .Sanitizable }}
+
+				if input.{{ .Name }} != nil {
+					if err := {{ $schema.PredicatePackage }}.{{ .Name }}Validator({{ if not .SliceInput }}*{{ end }}input.{{ .Name }}); err != nil {
+						logSanitizedIngestField(ctx, "{{ $schema.Snake }}", "{{ .Snake }}", err)
+						input.{{ .Name }} = nil
+					}
+				}
+{{- end }}
+{{- end }}
 {{- if .RuntimeDefaults }}
 
 				if integration != nil {


### PR DESCRIPTION
All of the ent types get a individual validator you can use as a part of the normal schema generation; when there's validator attached to a field, the entityops registry now includes a field check and then an validation - if the validation fails, we simply omit the field from the down stream create input (effectively discarding the field if it didn't pass validation).  The new entityops registry output looks like this:

```go
		Ingest: &IngestCapability{
			Topic: gala.NamespacedTopic[IngestRequest](IngestTopics, "asset.ingest.requested"),
			prepare: func(ctx context.Context, integration *generated.Integration, payload json.RawMessage) (json.RawMessage, error) {
				ref := SchemaRef{Schema: "asset", Operation: refOpCreate}

				input, err := jsonx.Decode[generated.CreateAssetInput](payload)
				if err != nil {
					return nil, logError(ctx, ref, ErrDecodeFailed, err)
				}

====== NEW =====>

				if input.DisplayName != nil {
					if err := asset.DisplayNameValidator(*input.DisplayName); err != nil {
						logSanitizedIngestField(ctx, "asset", "display_name", err)
						input.DisplayName = nil
					}
				}

				if input.OwnerID != nil {
					if err := asset.OwnerIDValidator(*input.OwnerID); err != nil {
						logSanitizedIngestField(ctx, "asset", "owner_id", err)
						input.OwnerID = nil
					}
				}
======== >
```