### PR TITLE
fix: sanitize optional string-slice fields

### DIFF
--- a/entityops/generator.go
+++ b/entityops/generator.go
@@ -356,11 +356,15 @@ func ingestSanitizable(field *gen.Field, im integrationFieldMeta) bool {
 		return false
 	}
 
-	if field.Type == nil || field.HasGoType() {
+	if field.Type == nil {
 		return false
 	}
 
-	return field.Type.Type == entfield.TypeString || field.Type.String() == "[]string"
+	if field.Type.String() == "[]string" {
+		return true
+	}
+
+	return field.Type.Type == entfield.TypeString && !field.HasGoType()
 }
 
 // collectEntityData iterates the ent graph and collects every primary schema. Optional


### PR DESCRIPTION
`field.Strings` fields carry a `[]string` Go type, so the `HasGoType` exclusion skipped them  (invalid values in fields like `email_aliases` still failed the whole record instead of being dropped)